### PR TITLE
Add Angle::as_hms

### DIFF
--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -25,6 +25,11 @@ module Astronoby
           Kernel.const_get(class_name).new(angle)
         end
       end
+
+      def as_hms(hour, minute, second)
+        angle = hour + minute / 60.0 + second / 3600.0
+        Kernel.const_get(UNIT_CLASS_NAMES[HOURS]).new(angle)
+      end
     end
 
     UNITS.each do |unit|

--- a/lib/astronoby/coordinates/equatorial.rb
+++ b/lib/astronoby/coordinates/equatorial.rb
@@ -56,21 +56,21 @@ module Astronoby
       def to_ecliptic(epoch:)
         obliquity = Astronoby::Obliquity.for_epoch(epoch)
         obliquity_in_radians = obliquity.value.to_radians.value
-        right_ascension_in_hours = @right_ascension.to_radians.value * 15
+        right_ascension_in_radians = @right_ascension.to_radians.value
         declination_in_radians = @declination.to_radians.value
 
         y = Astronoby::Angle.as_radians(
-          Math.sin(right_ascension_in_hours) * Math.cos(obliquity_in_radians) +
+          Math.sin(right_ascension_in_radians) * Math.cos(obliquity_in_radians) +
           Math.tan(declination_in_radians) * Math.sin(obliquity_in_radians)
         )
-        x = Astronoby::Angle.as_radians(Math.cos(right_ascension_in_hours))
+        x = Astronoby::Angle.as_radians(Math.cos(right_ascension_in_radians))
         r = Astronoby::Angle.as_radians(Math.atan(y.value / x.value))
         longitude = Astronoby::Util::Trigonometry.adjustement_for_arctangent(y, x, r)
 
         latitude = Astronoby::Angle.as_radians(
           Math.asin(
             Math.sin(declination_in_radians) * Math.cos(obliquity_in_radians) -
-            Math.cos(declination_in_radians) * Math.sin(obliquity_in_radians) * Math.sin(right_ascension_in_hours)
+            Math.cos(declination_in_radians) * Math.sin(obliquity_in_radians) * Math.sin(right_ascension_in_radians)
           )
         )
 

--- a/spec/astronoby/angle_spec.rb
+++ b/spec/astronoby/angle_spec.rb
@@ -13,6 +13,23 @@ RSpec.describe Astronoby::Angle do
     end
   end
 
+  describe "::as_hms" do
+    it "returns an Angle object" do
+      angle = described_class.as_hms(12, 15, 10)
+      expect(angle).to be_a(described_class)
+    end
+
+    it "returns an Angle in Hour" do
+      angle = described_class.as_hms(12, 15, 10)
+      expect(angle).to be_a(Astronoby::Hour)
+    end
+
+    it "converts HMS format into decimal format" do
+      angle = described_class.as_hms(12, 15, 45)
+      expect(angle.value).to eq(12.2625)
+    end
+  end
+
   describe "::as_hours" do
     subject { described_class.as_hours(180) }
 

--- a/spec/astronoby/body_spec.rb
+++ b/spec/astronoby/body_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Astronoby::Body do
     #  Edition: MIT Press
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns the body's rising time" do
-      right_ascension = Astronoby::Angle.as_hours(BigDecimal("5.916667"))
+      right_ascension = Astronoby::Angle.as_hms(5, 55, 0)
       declination = Astronoby::Angle.as_degrees(BigDecimal("7.5"))
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
@@ -31,7 +31,7 @@ RSpec.describe Astronoby::Body do
     #  Edition: MIT Press
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns nil as the body doesn't rise for the observer" do
-      right_ascension = Astronoby::Angle.as_hours(BigDecimal("90"))
+      right_ascension = Astronoby::Angle.as_hms(6, 0, 0)
       declination = Astronoby::Angle.as_degrees(BigDecimal("-60"))
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
@@ -79,7 +79,7 @@ RSpec.describe Astronoby::Body do
     #  Edition: MIT Press
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns the body's rising azimuth" do
-      right_ascension = Astronoby::Angle.as_hours(BigDecimal("5.916667"))
+      right_ascension = Astronoby::Angle.as_hms(5, 55, 0)
       declination = Astronoby::Angle.as_degrees(BigDecimal("7.5"))
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
@@ -104,7 +104,7 @@ RSpec.describe Astronoby::Body do
     #  Edition: MIT Press
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns the body's setting time" do
-      right_ascension = Astronoby::Angle.as_hours(BigDecimal("5.916667"))
+      right_ascension = Astronoby::Angle.as_hms(5, 55, 0)
       declination = Astronoby::Angle.as_degrees(BigDecimal("7.5"))
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
@@ -127,7 +127,7 @@ RSpec.describe Astronoby::Body do
     #  Edition: MIT Press
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns nil as the body doesn't set for the observer" do
-      right_ascension = Astronoby::Angle.as_hours(BigDecimal("90"))
+      right_ascension = Astronoby::Angle.as_hms(6, 0, 0)
       declination = Astronoby::Angle.as_degrees(BigDecimal("-60"))
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
@@ -175,7 +175,7 @@ RSpec.describe Astronoby::Body do
     #  Edition: MIT Press
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns the body's setting azimuth" do
-      right_ascension = Astronoby::Angle.as_hours(BigDecimal("5.916667"))
+      right_ascension = Astronoby::Angle.as_hms(5, 55, 0)
       declination = Astronoby::Angle.as_degrees(BigDecimal("7.5"))
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,

--- a/spec/astronoby/coordinates/equatorial_spec.rb
+++ b/spec/astronoby/coordinates/equatorial_spec.rb
@@ -15,7 +15,12 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
       ).to be_an_instance_of(Astronoby::Coordinates::Horizontal)
     end
 
-    context "with real life arguments (Venus, from Virginia, USA)" do
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 5 - Stars in the Nighttime Sky
+    context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2016, 1, 21, 21, 30, 0, "-05:00")
         latitude = BigDecimal("38")
@@ -35,9 +40,7 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
         )
 
         described_class.new(
-          right_ascension: Astronoby::Angle.as_hours(
-            BigDecimal("17.731666666666667")
-          ),
+          right_ascension: Astronoby::Angle.as_hms(17, 43, 54),
           declination: Astronoby::Angle.as_degrees(
             BigDecimal("-22.166666666666667")
           )
@@ -45,80 +48,27 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
       end
     end
 
-    context "with real life arguments (Betelgeuse, from Virginia, USA)" do
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 5 - Stars in the Nighttime Sky
+    context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2016, 1, 21, 21, 45, 0, "-05:00")
         latitude = BigDecimal("38")
         longitude = BigDecimal("-78")
 
-        expect(Astronoby::Coordinates::Horizontal).to(
-          receive(:new).with(
-            azimuth: Astronoby::Angle.as_degrees(
-              BigDecimal("171.08405974991367")
-            ),
-            altitude: Astronoby::Angle.as_degrees(
-              BigDecimal("59.21671281430846")
-            ),
-            latitude: latitude,
-            longitude: longitude
-          )
-        )
-
-        described_class.new(
-          right_ascension: Astronoby::Angle.as_hours(
-            BigDecimal("5.916090944444444")
-          ),
-          declination: Astronoby::Angle.as_degrees(
-            BigDecimal("7.498241083333333")
-          )
-        ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
-      end
-    end
-
-    context "with real life arguments (Mars, from Valencia, Spain)" do
-      it "computes properly" do
-        time = Time.new(2022, 12, 8, 6, 22, 33, "+01:00")
-        latitude = BigDecimal("39.46975")
-        longitude = BigDecimal("-0.377389")
-
-        expect(Astronoby::Coordinates::Horizontal).to(
-          receive(:new).with(
-            azimuth: Astronoby::Angle.as_degrees(
-              BigDecimal("285.64541526536471")
-            ),
-            altitude: Astronoby::Angle.as_degrees(
-              BigDecimal("21.03703466806004")
-            ),
-            latitude: latitude,
-            longitude: longitude
-          )
-        )
-
-        described_class.new(
-          right_ascension: Astronoby::Angle.as_hours(BigDecimal("4.97602775")),
-          declination: Astronoby::Angle.as_degrees(
-            BigDecimal("24.992300833333333")
-          )
-        ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
-      end
-    end
-
-    context "with real life arguments (Mars, from Paris, France)" do
-      it "computes properly" do
-        time = Time.utc(2022, 12, 6, 23, 48, 0)
-        latitude = BigDecimal("48.854419")
-        longitude = BigDecimal("2.482681")
-
         horizontal_coordinates = described_class.new(
-          right_ascension: Astronoby::Angle.as_hours(BigDecimal("5.0109194444")),
-          declination: Astronoby::Angle.as_degrees(BigDecimal("24.99463888"))
+          right_ascension: Astronoby::Angle.as_hms(5, 54, 58),
+          declination: Astronoby::Angle.as_degrees(BigDecimal("7.498241083333333"))
         ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
 
         expect(horizontal_coordinates.altitude.to_dms.format).to(
-          eq("+66° 8′ 24.6201″")
+          eq("+59° 13′ 0.0331″")
         )
         expect(horizontal_coordinates.azimuth.to_dms.format).to(
-          eq("+180° 8′ 10.6833″")
+          eq("+171° 5′ 0.5215″")
         )
       end
     end
@@ -135,7 +85,7 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
         longitude = -100
 
         horizontal_coordinates = described_class.new(
-          right_ascension: Astronoby::Angle.as_hours(6),
+          right_ascension: Astronoby::Angle.as_hms(6, 0, 0),
           declination: Astronoby::Angle.as_degrees(-60)
         ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
 
@@ -157,7 +107,7 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     #  Chapter: 4 - Orbits and Coordinate Systems
     context "with real life arguments (book example)" do
       it "computes properly" do
-        right_ascension = Astronoby::Angle.as_degrees(BigDecimal("11.17027"))
+        right_ascension = Astronoby::Angle.as_hms(11, 10, 13)
         declination = Astronoby::Angle.as_degrees(BigDecimal("30.09444"))
         epoch = Astronoby::Epoch::J2000
 
@@ -167,10 +117,10 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
         ).to_ecliptic(epoch: epoch)
 
         expect(ecliptic_coordinates.latitude.to_dms.format).to(
-          eq("+22° 41′ 53.7254″")
+          eq("+22° 41′ 53.8784″")
         )
         expect(ecliptic_coordinates.longitude.to_dms.format).to(
-          eq("+156° 19′ 8.6097″")
+          eq("+156° 19′ 8.9669″")
         )
       end
     end
@@ -179,7 +129,7 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
   describe "#to_epoch" do
     it "returns a new instance of Astronoby::Coordinates::Equatorial" do
       coordinates = described_class.new(
-        right_ascension: Astronoby::Angle.as_hours(12),
+        right_ascension: Astronoby::Angle.as_hms(12, 0, 0),
         declination: Astronoby::Angle.as_degrees(180),
         epoch: Astronoby::Epoch::J2000
       )

--- a/spec/astronoby/coordinates/horizontal_spec.rb
+++ b/spec/astronoby/coordinates/horizontal_spec.rb
@@ -13,86 +13,48 @@ RSpec.describe Astronoby::Coordinates::Horizontal do
       ).to be_a(Astronoby::Coordinates::Equatorial)
     end
 
-    context "with real life arguments (Betelgeuse, from Virginia, USA)" do
-      it "computes properly" do
-        expect(Astronoby::Coordinates::Equatorial).to(
-          receive(:new).with(
-            right_ascension: Astronoby::Angle.as_hours(
-              BigDecimal("5.91611614366334")
-            ),
-            declination: Astronoby::Angle.as_degrees(
-              BigDecimal("7.49824143730992")
-            )
-          )
-        )
-
-        described_class.new(
-          azimuth: Astronoby::Angle.as_degrees(BigDecimal("171.083333")),
-          altitude: Astronoby::Angle.as_degrees(BigDecimal("59.216667")),
-          latitude: BigDecimal("38"),
-          longitude: BigDecimal("-78")
-        ).to_equatorial(time: Time.new(2016, 1, 21, 21, 45, 0, "-05:00"))
-      end
-    end
-
-    context "with real life arguments (Venus, from Virginia, USA)" do
-      it "computes properly" do
-        expect(Astronoby::Coordinates::Equatorial).to(
-          receive(:new).with(
-            right_ascension: Astronoby::Angle.as_hours(
-              BigDecimal("17.73134982385581")
-            ),
-            declination: Astronoby::Angle.as_degrees(
-              BigDecimal("-22.17638923277082")
-            )
-          )
-        )
-
-        described_class.new(
-          azimuth: Astronoby::Angle.as_degrees(BigDecimal("341.5617")),
-          altitude: Astronoby::Angle.as_degrees(BigDecimal("-73.46587")),
-          latitude: BigDecimal("38"),
-          longitude: BigDecimal("-78")
-        ).to_equatorial(time: Time.new(2016, 1, 21, 21, 30, 0, "-05:00"))
-      end
-    end
-
-    context "with real life arguments (Mars, from Valencia, Spain)" do
-      it "computes properly" do
-        expect(Astronoby::Coordinates::Equatorial).to(
-          receive(:new).with(
-            right_ascension: Astronoby::Angle.as_hours(
-              BigDecimal("4.97623177977841")
-            ),
-            declination: Astronoby::Angle.as_degrees(
-              BigDecimal("24.99228390281957")
-            )
-          )
-        )
-
-        described_class.new(
-          azimuth: Astronoby::Angle.as_degrees(BigDecimal("285.6437")),
-          altitude: Astronoby::Angle.as_degrees(BigDecimal("21.0393")),
-          latitude: BigDecimal("39.46975"),
-          longitude: BigDecimal("-0.377389")
-        ).to_equatorial(time: Time.new(2022, 12, 8, 6, 22, 33, "+01:00"))
-      end
-    end
-
-    context "with real life arguments (Mars, from Paris, France)" do
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 5 - Stars in the Nighttime Sky
+    context "with real life arguments (book example)" do
       it "computes properly" do
         equatorial_coordinates = described_class.new(
-          azimuth: Astronoby::Angle.as_degrees(BigDecimal("180.135207714")),
-          altitude: Astronoby::Angle.as_degrees(BigDecimal("66.14017303")),
-          latitude: BigDecimal("48.854419"),
-          longitude: BigDecimal("2.482681")
-        ).to_equatorial(time: Time.utc(2022, 12, 6, 23, 48, 0))
+          azimuth: Astronoby::Angle.as_degrees(BigDecimal("171.0833")),
+          altitude: Astronoby::Angle.as_degrees(BigDecimal("59.2167")),
+          latitude: 38,
+          longitude: -78
+        ).to_equatorial(time: Time.new(2016, 1, 21, 21, 45, 0, "-05:00"))
 
         expect(equatorial_coordinates.right_ascension.to_hms.format).to(
-          eq("5h 0m 39.427s")
+          eq("5h 54m 58.0211s")
         )
         expect(equatorial_coordinates.declination.to_dms.format).to(
-          eq("+24° 59′ 40.6999″")
+          eq("+7° 29′ 53.7945″")
+        )
+      end
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 5 - Stars in the Nighttime Sky
+    context "with real life arguments (book example)" do
+      it "computes properly" do
+        equatorial_coordinates = described_class.new(
+          azimuth: Astronoby::Angle.as_degrees(BigDecimal("341.55472")),
+          altitude: Astronoby::Angle.as_degrees(BigDecimal("-73.455278")),
+          latitude: 38,
+          longitude: -78
+        ).to_equatorial(time: Time.new(2016, 1, 21, 21, 30, 0, "-05:00"))
+
+        expect(equatorial_coordinates.right_ascension.to_hms.format).to(
+          eq("17h 43m 54.0942s")
+        )
+        expect(equatorial_coordinates.declination.to_dms.format).to(
+          eq("-22° 10′ 0.203″")
         )
       end
     end

--- a/spec/astronoby/precession_spec.rb
+++ b/spec/astronoby/precession_spec.rb
@@ -2,8 +2,13 @@
 
 RSpec.describe Astronoby::Precession do
   describe "::for_equatorial_coordinates" do
+    # Source:
+    #  Title: Practical Astronomy with your Calculator or Spreadsheet
+    #  Authors: Peter Duffett-Smith and Jonathan Zwart
+    #  Edition: Cambridge University Press
+    #  Chapter: 34 - Precession
     it "returns equatorial coordinates with the right epoch" do
-      right_ascension = Astronoby::Angle.as_hours(BigDecimal("9.178611"))
+      right_ascension = Astronoby::Angle.as_hms(9, 10, 43)
       declination = Astronoby::Angle.as_degrees(BigDecimal("14.390278"))
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
@@ -27,7 +32,7 @@ RSpec.describe Astronoby::Precession do
     #  Edition: Cambridge University Press
     #  Chapter: 34 - Precession
     it "returns the right new equatorial coordinates" do
-      right_ascension = Astronoby::Angle.as_hours(9.178611)
+      right_ascension = Astronoby::Angle.as_hms(9, 10, 43)
       declination = Astronoby::Angle.as_degrees(14.390278)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
@@ -41,7 +46,7 @@ RSpec.describe Astronoby::Precession do
       )
 
       expect(precessed_coordinates.right_ascension.to_hours.to_hms.format).to(
-        eq("9h 12m 20.1573s")
+        eq("9h 12m 20.1577s")
       )
       expect(precessed_coordinates.declination.to_dms.format).to(
         eq("+14° 16′ 7.6514″")
@@ -54,7 +59,7 @@ RSpec.describe Astronoby::Precession do
     #  Edition: MIT Press
     #  Chapter: 4 - Orbits and Coordinate Systems
     it "returns the right new equatorial coordinates" do
-      right_ascension = Astronoby::Angle.as_hours(12.535)
+      right_ascension = Astronoby::Angle.as_hms(12, 32, 6)
       declination = Astronoby::Angle.as_degrees(30.094444)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
@@ -81,7 +86,7 @@ RSpec.describe Astronoby::Precession do
     #  Edition: MIT Press
     #  Chapter: 4 - Orbits and Coordinate Systems
     it "returns the right new equatorial coordinates" do
-      right_ascension = Astronoby::Angle.as_hours(12.576111)
+      right_ascension = Astronoby::Angle.as_hms(12, 34, 34)
       declination = Astronoby::Angle.as_degrees(29.818889)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
@@ -95,7 +100,7 @@ RSpec.describe Astronoby::Precession do
       )
 
       expect(precessed_coordinates.right_ascension.to_hours.to_hms.format).to(
-        eq("12h 35m 18.3826s")
+        eq("12h 35m 18.383s")
       )
       expect(precessed_coordinates.declination.to_dms.format).to(
         eq("+29° 44′ 10.8633″")


### PR DESCRIPTION
Fixes #6

Before, we had to convert angles in hours into decimal values to set up coordinates. This was a bit annoying as most of the time the coordinates as specified in HMS format, so the test example often differed from the books.

Now, it is possible to create an angle in hours from HMS values. Test examples are closer to what's written in source books.