### PR TITLE
Consider latitude and longitude as angles

### DIFF
--- a/lib/astronoby/coordinates/equatorial.rb
+++ b/lib/astronoby/coordinates/equatorial.rb
@@ -23,15 +23,16 @@ module Astronoby
 
         hour_angle_value += 24 if hour_angle_value.negative?
         hour_angle_value -= 24 if hour_angle_value > 24
-        hour_angle = Astronoby::Angle.as_degrees(hour_angle_value * BigDecimal("15"))
+        hour_angle = Astronoby::Angle.as_hours(hour_angle_value)
 
-        latitude_radians = Astronoby::Util::Trigonometry.to_radians(latitude)
+        latitude_radians = latitude.to_radians.value
+        declination_radians = @declination.to_radians.value
 
-        t0 = Math.sin(@declination.to_radians.value) * Math.sin(latitude_radians) +
-          Math.cos(@declination.to_radians.value) * Math.cos(latitude_radians) * Math.cos(hour_angle.to_radians.value)
+        t0 = Math.sin(declination_radians) * Math.sin(latitude_radians) +
+          Math.cos(declination_radians) * Math.cos(latitude_radians) * Math.cos(hour_angle.to_radians.value)
         altitude = Astronoby::Angle.as_radians(Math.asin(t0))
 
-        t1 = Math.sin(@declination.to_radians.value) -
+        t1 = Math.sin(declination_radians) -
           Math.sin(latitude_radians) * Math.sin(altitude.to_radians.value)
         t2 = t1 / (Math.cos(latitude_radians) * Math.cos(altitude.to_radians.value))
         sin_hour_angle = Math.sin(hour_angle.to_radians.value)

--- a/lib/astronoby/coordinates/horizontal.rb
+++ b/lib/astronoby/coordinates/horizontal.rb
@@ -18,7 +18,7 @@ module Astronoby
       end
 
       def to_equatorial(time:)
-        latitude_radians = Astronoby::Util::Trigonometry.to_radians(@latitude)
+        latitude_radians = @latitude.to_radians.value
 
         t0 = Math.sin(@altitude.to_radians.value) * Math.sin(latitude_radians) +
           Math.cos(@altitude.to_radians.value) * Math.cos(latitude_radians) * Math.cos(@azimuth.to_radians.value)
@@ -28,21 +28,23 @@ module Astronoby
         t1 = Math.sin(@altitude.to_radians.value) -
           Math.sin(latitude_radians) * Math.sin(declination.to_radians.value)
 
-        hour_angle_degrees = Astronoby::Util::Trigonometry.to_degrees(
+        hour_angle_degrees = Astronoby::Angle.as_radians(
           Math.acos(
             t1 / (Math.cos(latitude_radians) * Math.cos(declination.to_radians.value))
           )
-        )
+        ).to_degrees
 
         if Math.sin(@azimuth.to_radians.value).positive?
-          hour_angle_degrees = BigDecimal("360") - hour_angle_degrees
+          hour_angle_degrees = Astronoby::Angle.as_degrees(
+            BigDecimal("360") - hour_angle_degrees.value
+          )
         end
 
-        hour_angle_hours = hour_angle_degrees / 15r
+        hour_angle_hours = hour_angle_degrees.to_hours
         right_ascension_decimal = Astronoby::Util::Time.local_sidereal_time(
           time: time,
           longitude: @longitude
-        ) - hour_angle_hours
+        ) - hour_angle_hours.value
         right_ascension_decimal += 24 if right_ascension_decimal.negative?
         right_ascension = Astronoby::Angle.as_hours(right_ascension_decimal)
 

--- a/lib/astronoby/util/time.rb
+++ b/lib/astronoby/util/time.rb
@@ -83,20 +83,14 @@ module Astronoby
         end
 
         def local_sidereal_time(time:, longitude:)
-          universal_time = time.utc
-          greenwich_sidereal_time = ut_to_gmst(universal_time)
-
-          adjustment = longitude / 15.0
-          greenwich_sidereal_time + adjustment
+          ut_to_gmst(time.utc) + longitude.to_hours.value
         end
 
         def lst_to_gmst(lst:, longitude:)
-          adjustment = longitude.to_degrees.value / 15.0
+          gmst = lst - longitude.to_hours.value
 
           # If gmst negative, add 24 hours to the date
           # If gmst is greater than 24, subtract 24 hours from the date
-          gmst = lst - adjustment
-
           gmst += 24 if gmst.negative?
           gmst -= 24 if gmst > 24
 

--- a/lib/astronoby/util/trigonometry.rb
+++ b/lib/astronoby/util/trigonometry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bigdecimal"
+require "bigdecimal/math"
 
 module Astronoby
   module Util
@@ -9,14 +9,6 @@ module Astronoby
       PI = BigMath.PI(PRECISION)
 
       class << self
-        def to_radians(degrees_angle)
-          degrees_angle * PI / BigDecimal("180")
-        end
-
-        def to_degrees(radians_angle)
-          radians_angle * BigDecimal("180") / PI
-        end
-
         # Source:
         #  Title: Celestial Calculations
         #  Author: J. L. Lawrence

--- a/spec/astronoby/body_spec.rb
+++ b/spec/astronoby/body_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Astronoby::Body do
       coordinates = Astronoby::Coordinates::Horizontal.new(
         azimuth: Astronoby::Angle.as_degrees(90),
         altitude: Astronoby::Angle.as_degrees(45),
-        latitude: 38.25,
-        longitude: -78.3
+        latitude: Astronoby::Angle.as_degrees(38.25),
+        longitude: Astronoby::Angle.as_degrees(-78.3)
       ).to_equatorial(time: Time.new(2015, 6, 6, 21, 0, 0, "-04:00"))
       body = described_class.new(coordinates)
 
@@ -153,8 +153,8 @@ RSpec.describe Astronoby::Body do
       coordinates = Astronoby::Coordinates::Horizontal.new(
         azimuth: Astronoby::Angle.as_degrees(90),
         altitude: Astronoby::Angle.as_degrees(45),
-        latitude: 38.25,
-        longitude: -78.3
+        latitude: Astronoby::Angle.as_degrees(38.25),
+        longitude: Astronoby::Angle.as_degrees(-78.3)
       ).to_equatorial(time: Time.new(2015, 6, 6, 21, 0, 0, "-04:00"))
       body = described_class.new(coordinates)
 

--- a/spec/astronoby/coordinates/equatorial_spec.rb
+++ b/spec/astronoby/coordinates/equatorial_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
   describe "#to_horizontal" do
     it "returns a new instance of Astronoby::Coordinates::Horizontal" do
       time = Time.new
-      latitude = 50
-      longitude = 0
+      latitude = Astronoby::Angle.as_degrees(50)
+      longitude = Astronoby::Angle.as_degrees(0)
 
       expect(
         described_class.new(
@@ -23,8 +23,8 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2016, 1, 21, 21, 30, 0, "-05:00")
-        latitude = 38
-        longitude = -78
+        latitude = Astronoby::Angle.as_degrees(38)
+        longitude = Astronoby::Angle.as_degrees(-78)
 
         horizontal_coordinates = described_class.new(
           right_ascension: Astronoby::Angle.as_hms(17, 43, 54),
@@ -48,8 +48,8 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2016, 1, 21, 21, 45, 0, "-05:00")
-        latitude = 38
-        longitude = -78
+        latitude = Astronoby::Angle.as_degrees(38)
+        longitude = Astronoby::Angle.as_degrees(-78)
 
         horizontal_coordinates = described_class.new(
           right_ascension: Astronoby::Angle.as_hms(5, 54, 58),
@@ -73,8 +73,8 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2015, 12, 1, 9, 0, 0, "-08:00")
-        latitude = 45
-        longitude = -100
+        latitude = Astronoby::Angle.as_degrees(45)
+        longitude = Astronoby::Angle.as_degrees(-100)
 
         horizontal_coordinates = described_class.new(
           right_ascension: Astronoby::Angle.as_hms(6, 0, 0),

--- a/spec/astronoby/coordinates/horizontal_spec.rb
+++ b/spec/astronoby/coordinates/horizontal_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Astronoby::Coordinates::Horizontal do
     it "returns a new instance of Astronoby::Coordinates::Equatorial" do
       expect(
         described_class.new(
-          azimuth: Astronoby::Angle.as_dms(100, 0, 0),
-          altitude: Astronoby::Angle.as_dms(80, 0, 0),
-          latitude: 50,
-          longitude: 0
+          azimuth: Astronoby::Angle.as_degrees(100),
+          altitude: Astronoby::Angle.as_degrees(80),
+          latitude: Astronoby::Angle.as_degrees(50),
+          longitude: Astronoby::Angle.as_degrees(0)
         ).to_equatorial(time: Time.new)
       ).to be_a(Astronoby::Coordinates::Equatorial)
     end
@@ -23,8 +23,8 @@ RSpec.describe Astronoby::Coordinates::Horizontal do
         equatorial_coordinates = described_class.new(
           azimuth: Astronoby::Angle.as_dms(171, 5, 0),
           altitude: Astronoby::Angle.as_dms(59, 13, 0),
-          latitude: 38,
-          longitude: -78
+          latitude: Astronoby::Angle.as_degrees(38),
+          longitude: Astronoby::Angle.as_degrees(-78)
         ).to_equatorial(time: Time.new(2016, 1, 21, 21, 45, 0, "-05:00"))
 
         expect(equatorial_coordinates.right_ascension.to_hms.format).to(
@@ -46,8 +46,8 @@ RSpec.describe Astronoby::Coordinates::Horizontal do
         equatorial_coordinates = described_class.new(
           azimuth: Astronoby::Angle.as_dms(341, 33, 17),
           altitude: Astronoby::Angle.as_dms(-73, 27, 19),
-          latitude: 38,
-          longitude: -78
+          latitude: Astronoby::Angle.as_degrees(38),
+          longitude: Astronoby::Angle.as_degrees(-78)
         ).to_equatorial(time: Time.new(2016, 1, 21, 21, 30, 0, "-05:00"))
 
         expect(equatorial_coordinates.right_ascension.to_hms.format).to(
@@ -69,8 +69,8 @@ RSpec.describe Astronoby::Coordinates::Horizontal do
         equatorial_coordinates = described_class.new(
           azimuth: Astronoby::Angle.as_degrees(90),
           altitude: Astronoby::Angle.as_degrees(45),
-          latitude: 38.25,
-          longitude: -78.3
+          latitude: Astronoby::Angle.as_degrees(38.25),
+          longitude: Astronoby::Angle.as_degrees(-78.3)
         ).to_equatorial(time: Time.new(2015, 6, 6, 21, 0, 0, "-04:00"))
 
         expect(equatorial_coordinates.right_ascension.to_hms.format).to(

--- a/spec/astronoby/util/time_spec.rb
+++ b/spec/astronoby/util/time_spec.rb
@@ -70,7 +70,10 @@ RSpec.describe Astronoby::Util::Time do
   describe "::local_sidereal_time" do
     it "returns a BigDecimal" do
       expect(
-        described_class.local_sidereal_time(time: Time.new, longitude: 1)
+        described_class.local_sidereal_time(
+          time: Time.new,
+          longitude: Astronoby::Angle.as_degrees(1)
+        )
       ).to be_an_instance_of(BigDecimal)
     end
 
@@ -78,7 +81,7 @@ RSpec.describe Astronoby::Util::Time do
       it "computes the right time (1h 18m 34s)" do
         local_sidereal_time = described_class.local_sidereal_time(
           time: Time.new(2014, 12, 12, 20, 0, 0, "-05:00"),
-          longitude: -77
+          longitude: Astronoby::Angle.as_degrees(-77)
         )
 
         hour = local_sidereal_time.to_i
@@ -95,7 +98,7 @@ RSpec.describe Astronoby::Util::Time do
       it "computes the right time" do
         local_sidereal_time = described_class.local_sidereal_time(
           time: Time.new(2000, 7, 5, 12, 0, 0, "+05:00"),
-          longitude: 60
+          longitude: Astronoby::Angle.as_degrees(60)
         )
 
         hour = local_sidereal_time.to_i

--- a/spec/astronoby/util/trigonometry_spec.rb
+++ b/spec/astronoby/util/trigonometry_spec.rb
@@ -1,26 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Astronoby::Util::Trigonometry do
-  describe "::to_radians" do
-    it "returns a BigDecimal" do
-      expect(described_class.to_radians(3)).to be_an_instance_of(BigDecimal)
-    end
-
-    it "returns a converts an degrees angle to a radians one" do
-      expect(described_class.to_radians(180)).to eq(BigMath.PI(10))
-    end
-  end
-
-  describe "::to_degrees" do
-    it "returns a BigDecimal" do
-      expect(described_class.to_degrees(90)).to be_an_instance_of(BigDecimal)
-    end
-
-    it "returns a converts an radians angle to a degrees one" do
-      expect(described_class.to_degrees(BigMath.PI(10))).to eq(180)
-    end
-  end
-
   # Source:
   #  Title: Celestial Calculations
   #  Author: J. L. Lawrence


### PR DESCRIPTION
Before, latitude and longitude were often considered as plain values, implied in degrees. A few conversions were done with magic numbers such as "* 15" or "/ 15" when dealing with angles in hours.

Now, latitude and longitude are always defined as Angle objects. This makes it easier to manipulate them and convert them without introducing magic numbers. It also goes with the philosophy of the library where most things are objects.

As a bonus, this enabled to remove to legacy code.

Fixed #8