### PR TITLE
Arithmetic methods support for `Angle`

### DIFF
--- a/lib/astronoby/aberration.rb
+++ b/lib/astronoby/aberration.rb
@@ -20,16 +20,15 @@ module Astronoby
     #  Chapter: 36 - Aberration
     def apply
       delta_longitude = Astronoby::Angle.as_degrees(
-        -20.5 *
-        Math.cos(
-          (@sun_longitude - @coordinates.longitude).radians
-        ) / Math.cos(@coordinates.latitude.radians) / 3600
+        -20.5 * (
+          @sun_longitude - @coordinates.longitude
+        ).cos / @coordinates.latitude.cos / 3600
       )
 
       delta_latitude = Astronoby::Angle.as_degrees(
         -20.5 *
-        Math.sin((@sun_longitude - @coordinates.longitude).radians) *
-        Math.sin(@coordinates.latitude.radians) / 3600
+        (@sun_longitude - @coordinates.longitude).sin *
+        @coordinates.latitude.sin / 3600
       )
 
       Astronoby::Coordinates::Ecliptic.new(

--- a/lib/astronoby/aberration.rb
+++ b/lib/astronoby/aberration.rb
@@ -33,12 +33,8 @@ module Astronoby
       )
 
       Astronoby::Coordinates::Ecliptic.new(
-        latitude: Astronoby::Angle.as_degrees(
-          @coordinates.latitude.degrees + delta_latitude.degrees
-        ),
-        longitude: Astronoby::Angle.as_degrees(
-          @coordinates.longitude.degrees + delta_longitude.degrees
-        )
+        latitude: @coordinates.latitude + delta_latitude,
+        longitude: @coordinates.longitude + delta_longitude
       )
     end
   end

--- a/lib/astronoby/aberration.rb
+++ b/lib/astronoby/aberration.rb
@@ -22,13 +22,13 @@ module Astronoby
       delta_longitude = Astronoby::Angle.as_degrees(
         -20.5 *
         Math.cos(
-          @sun_longitude.radians - @coordinates.longitude.radians
+          (@sun_longitude - @coordinates.longitude).radians
         ) / Math.cos(@coordinates.latitude.radians) / 3600
       )
 
       delta_latitude = Astronoby::Angle.as_degrees(
         -20.5 *
-        Math.sin(@sun_longitude.radians - @coordinates.longitude.radians) *
+        Math.sin((@sun_longitude - @coordinates.longitude).radians) *
         Math.sin(@coordinates.latitude.radians) / 3600
       )
 

--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -45,6 +45,21 @@ module Astronoby
         degrees = degree.abs + minute / MINUTES_PER_HOUR + second / SECONDS_PER_HOUR
         as_degrees(sign * degrees)
       end
+
+      def asin(ratio)
+        radians = Math.asin(ratio)
+        as_radians(radians)
+      end
+
+      def acos(ratio)
+        radians = Math.acos(ratio)
+        as_radians(radians)
+      end
+
+      def atan(ratio)
+        radians = Math.atan(ratio)
+        as_radians(radians)
+      end
     end
 
     attr_reader :radians

--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -69,6 +69,10 @@ module Astronoby
       self.class.as_radians(radians + other.radians)
     end
 
+    def -(other)
+      self.class.as_radians(@radians - other.radians)
+    end
+
     def str(format)
       case format
       when :dms then to_dms(degrees).format

--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -73,6 +73,18 @@ module Astronoby
       self.class.as_radians(@radians - other.radians)
     end
 
+    def sin
+      Math.sin(radians)
+    end
+
+    def cos
+      Math.cos(radians)
+    end
+
+    def tan
+      Math.tan(radians)
+    end
+
     def str(format)
       case format
       when :dms then to_dms(degrees).format

--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -70,7 +70,7 @@ module Astronoby
     end
 
     def +(other)
-      self.class.new(@value + other.value)
+      self.class.as_radians(radians + other.radians)
     end
 
     def str(format)

--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -47,24 +47,30 @@ module Astronoby
       end
     end
 
+    attr_reader :value
+
+    def initialize(value)
+      @value = if value.is_a?(Integer) || value.is_a?(BigDecimal)
+        BigDecimal(value)
+      else
+        BigDecimal(value, PRECISION)
+      end
+    end
+
     def radians
-      @angle
+      @value
     end
 
     def degrees
-      @angle * PI_IN_DEGREES / PI
+      @value * PI_IN_DEGREES / PI
     end
 
     def hours
-      @angle / RADIAN_PER_HOUR
+      @value / RADIAN_PER_HOUR
     end
 
-    def initialize(angle)
-      @angle = if angle.is_a?(Integer) || angle.is_a?(BigDecimal)
-        BigDecimal(angle)
-      else
-        BigDecimal(angle, PRECISION)
-      end
+    def +(other)
+      self.class.new(@value + other.value)
     end
 
     def str(format)

--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -47,26 +47,22 @@ module Astronoby
       end
     end
 
-    attr_reader :value
+    attr_reader :radians
 
-    def initialize(value)
-      @value = if value.is_a?(Integer) || value.is_a?(BigDecimal)
-        BigDecimal(value)
+    def initialize(radians)
+      @radians = if radians.is_a?(Integer) || radians.is_a?(BigDecimal)
+        BigDecimal(radians)
       else
-        BigDecimal(value, PRECISION)
+        BigDecimal(radians, PRECISION)
       end
     end
 
-    def radians
-      @value
-    end
-
     def degrees
-      @value * PI_IN_DEGREES / PI
+      @radians * PI_IN_DEGREES / PI
     end
 
     def hours
-      @value / RADIAN_PER_HOUR
+      @radians / RADIAN_PER_HOUR
     end
 
     def +(other)

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -50,7 +50,7 @@ module Astronoby
       ) * Math.tan(eccentric_anomaly.radians / 2)
 
       Astronoby::Angle.as_degrees(
-        (Astronoby::Angle.as_radians(Math.atan(tan)).degrees * 2) % 360
+        (Astronoby::Angle.atan(tan).degrees * 2) % 360
       )
     end
 

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -16,7 +16,7 @@ module Astronoby
       Coordinates::Ecliptic.new(
         latitude: Angle.zero,
         longitude: Angle.as_degrees(
-          (true_anomaly.degrees + longitude_at_perigee.degrees) % 360
+          (true_anomaly + longitude_at_perigee).degrees % 360
         )
       )
     end

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -33,7 +33,7 @@ module Astronoby
 
     def mean_anomaly
       Angle.as_degrees(
-        (longitude_at_base_epoch.degrees - longitude_at_perigee.degrees) % 360
+        (longitude_at_base_epoch - longitude_at_perigee).degrees % 360
       )
     end
 

--- a/lib/astronoby/body.rb
+++ b/lib/astronoby/body.rb
@@ -35,7 +35,7 @@ module Astronoby
       ar = azimuth_component(latitude: latitude)
       return nil if ar >= 1
 
-      Astronoby::Angle.as_radians(Math.acos(ar))
+      Astronoby::Angle.acos(ar)
     end
 
     # Source:

--- a/lib/astronoby/body.rb
+++ b/lib/astronoby/body.rb
@@ -72,17 +72,14 @@ module Astronoby
     private
 
     def azimuth_component(latitude:)
-      Math.sin(@equatorial_coordinates.declination.radians)./(
-        Math.cos(latitude.radians)
-      )
+      @equatorial_coordinates.declination.sin / latitude.cos
     end
 
     def h2(latitude:)
       ar = azimuth_component(latitude: latitude)
       return nil if ar >= 1
 
-      h1 = Math.tan(latitude.radians) *
-        Math.tan(@equatorial_coordinates.declination.radians)
+      h1 = latitude.tan * @equatorial_coordinates.declination.tan
       return nil if h1.abs > 1
 
       Astronoby::Angle.as_radians(Math.acos(-h1) / 15.0)

--- a/lib/astronoby/coordinates/ecliptic.rb
+++ b/lib/astronoby/coordinates/ecliptic.rb
@@ -17,24 +17,20 @@ module Astronoby
       #  Chapter: 4 - Orbits and Coordinate Systems
       def to_equatorial(epoch:)
         mean_obliquity = Astronoby::MeanObliquity.for_epoch(epoch)
-        obliquity_in_radians = mean_obliquity.value.radians
-        longitude_in_radians = @longitude.radians
-        latitude_in_radians = @latitude.radians
+        obliquity = mean_obliquity.value
 
         y = Astronoby::Angle.as_radians(
-          Math.sin(longitude_in_radians) * Math.cos(obliquity_in_radians) -
-          Math.tan(latitude_in_radians) * Math.sin(obliquity_in_radians)
+          @longitude.sin * obliquity.cos - @latitude.tan * obliquity.sin
         )
-        x = Astronoby::Angle.as_radians(Math.cos(longitude_in_radians))
+        x = Astronoby::Angle.as_radians(@longitude.cos)
         r = Astronoby::Angle.as_radians(Math.atan(y.radians / x.radians))
-        right_ascension = Astronoby::Angle.as_radians(
-          Astronoby::Util::Trigonometry.adjustement_for_arctangent(y, x, r).radians
-        )
+        right_ascension = Astronoby::Util::Trigonometry
+          .adjustement_for_arctangent(y, x, r)
 
         declination = Astronoby::Angle.as_radians(
           Math.asin(
-            Math.sin(latitude_in_radians) * Math.cos(obliquity_in_radians) +
-            Math.cos(latitude_in_radians) * Math.sin(obliquity_in_radians) * Math.sin(longitude_in_radians)
+            @latitude.sin * obliquity.cos +
+            @latitude.cos * obliquity.sin * @longitude.sin
           )
         )
 

--- a/lib/astronoby/coordinates/ecliptic.rb
+++ b/lib/astronoby/coordinates/ecliptic.rb
@@ -23,15 +23,13 @@ module Astronoby
           @longitude.sin * obliquity.cos - @latitude.tan * obliquity.sin
         )
         x = Astronoby::Angle.as_radians(@longitude.cos)
-        r = Astronoby::Angle.as_radians(Math.atan(y.radians / x.radians))
+        r = Astronoby::Angle.atan(y.radians / x.radians)
         right_ascension = Astronoby::Util::Trigonometry
           .adjustement_for_arctangent(y, x, r)
 
-        declination = Astronoby::Angle.as_radians(
-          Math.asin(
-            @latitude.sin * obliquity.cos +
-            @latitude.cos * obliquity.sin * @longitude.sin
-          )
+        declination = Astronoby::Angle.asin(
+          @latitude.sin * obliquity.cos +
+          @latitude.cos * obliquity.sin * @longitude.sin
         )
 
         Equatorial.new(

--- a/lib/astronoby/coordinates/equatorial.rb
+++ b/lib/astronoby/coordinates/equatorial.rb
@@ -31,20 +31,15 @@ module Astronoby
 
       def to_horizontal(time:, latitude:, longitude:)
         ha = @hour_angle || compute_hour_angle(time: time, longitude: longitude)
-
-        latitude_radians = latitude.radians
-        declination_radians = @declination.radians
-
-        t0 = Math.sin(declination_radians) * Math.sin(latitude_radians) +
-          Math.cos(declination_radians) * Math.cos(latitude_radians) * Math.cos(ha.radians)
+        t0 = @declination.sin * latitude.sin +
+          @declination.cos * latitude.cos * ha.cos
         altitude = Astronoby::Angle.as_radians(Math.asin(t0))
 
-        t1 = Math.sin(declination_radians) -
-          Math.sin(latitude_radians) * Math.sin(altitude.radians)
-        t2 = t1 / (Math.cos(latitude_radians) * Math.cos(altitude.radians))
-        sin_hour_angle = Math.sin(ha.radians)
+        t1 = @declination.sin - latitude.sin * altitude.sin
+        t2 = t1 / (latitude.cos * altitude.cos)
         azimuth = Astronoby::Angle.as_radians(Math.acos(t2))
-        if sin_hour_angle.positive?
+
+        if ha.sin.positive?
           azimuth = Astronoby::Angle.as_degrees(BigDecimal("360") - azimuth.degrees)
         end
 
@@ -63,22 +58,20 @@ module Astronoby
       #  Chapter: 4 - Orbits and Coordinate Systems
       def to_ecliptic(epoch:)
         mean_obliquity = Astronoby::MeanObliquity.for_epoch(epoch)
-        obliquity_in_radians = mean_obliquity.value.radians
-        right_ascension_in_radians = @right_ascension.radians
-        declination_in_radians = @declination.radians
+        obliquity = mean_obliquity.value
 
         y = Astronoby::Angle.as_radians(
-          Math.sin(right_ascension_in_radians) * Math.cos(obliquity_in_radians) +
-          Math.tan(declination_in_radians) * Math.sin(obliquity_in_radians)
+          @right_ascension.sin * obliquity.cos +
+            @declination.tan * obliquity.sin
         )
-        x = Astronoby::Angle.as_radians(Math.cos(right_ascension_in_radians))
+        x = Astronoby::Angle.as_radians(@right_ascension.cos)
         r = Astronoby::Angle.as_radians(Math.atan(y.radians / x.radians))
         longitude = Astronoby::Util::Trigonometry.adjustement_for_arctangent(y, x, r)
 
         latitude = Astronoby::Angle.as_radians(
           Math.asin(
-            Math.sin(declination_in_radians) * Math.cos(obliquity_in_radians) -
-            Math.cos(declination_in_radians) * Math.sin(obliquity_in_radians) * Math.sin(right_ascension_in_radians)
+            @declination.sin * obliquity.cos -
+              @declination.cos * obliquity.sin * @right_ascension.sin
           )
         )
 

--- a/lib/astronoby/coordinates/equatorial.rb
+++ b/lib/astronoby/coordinates/equatorial.rb
@@ -33,11 +33,11 @@ module Astronoby
         ha = @hour_angle || compute_hour_angle(time: time, longitude: longitude)
         t0 = @declination.sin * latitude.sin +
           @declination.cos * latitude.cos * ha.cos
-        altitude = Astronoby::Angle.as_radians(Math.asin(t0))
+        altitude = Astronoby::Angle.asin(t0)
 
         t1 = @declination.sin - latitude.sin * altitude.sin
         t2 = t1 / (latitude.cos * altitude.cos)
-        azimuth = Astronoby::Angle.as_radians(Math.acos(t2))
+        azimuth = Astronoby::Angle.acos(t2)
 
         if ha.sin.positive?
           azimuth = Astronoby::Angle.as_degrees(BigDecimal("360") - azimuth.degrees)
@@ -65,14 +65,12 @@ module Astronoby
             @declination.tan * obliquity.sin
         )
         x = Astronoby::Angle.as_radians(@right_ascension.cos)
-        r = Astronoby::Angle.as_radians(Math.atan(y.radians / x.radians))
+        r = Astronoby::Angle.atan(y.radians / x.radians)
         longitude = Astronoby::Util::Trigonometry.adjustement_for_arctangent(y, x, r)
 
-        latitude = Astronoby::Angle.as_radians(
-          Math.asin(
-            @declination.sin * obliquity.cos -
-              @declination.cos * obliquity.sin * @right_ascension.sin
-          )
+        latitude = Astronoby::Angle.asin(
+          @declination.sin * obliquity.cos -
+          @declination.cos * obliquity.sin * @right_ascension.sin
         )
 
         Ecliptic.new(

--- a/lib/astronoby/coordinates/horizontal.rb
+++ b/lib/astronoby/coordinates/horizontal.rb
@@ -18,23 +18,19 @@ module Astronoby
       end
 
       def to_equatorial(time:)
-        latitude_radians = @latitude.radians
-
-        t0 = Math.sin(@altitude.radians) * Math.sin(latitude_radians) +
-          Math.cos(@altitude.radians) * Math.cos(latitude_radians) * Math.cos(@azimuth.radians)
+        t0 = @altitude.sin * @latitude.sin +
+          @altitude.cos * @latitude.cos * @azimuth.cos
 
         declination = Astronoby::Angle.as_radians(Math.asin(t0))
 
-        t1 = Math.sin(@altitude.radians) -
-          Math.sin(latitude_radians) * Math.sin(declination.radians)
+        t1 = @altitude.sin -
+          @latitude.sin * declination.sin
 
         hour_angle_degrees = Astronoby::Angle.as_radians(
-          Math.acos(
-            t1 / (Math.cos(latitude_radians) * Math.cos(declination.radians))
-          )
+          Math.acos(t1 / (@latitude.cos * declination.cos))
         ).degrees
 
-        if Math.sin(@azimuth.radians).positive?
+        if @azimuth.sin.positive?
           hour_angle_degrees = Astronoby::Angle.as_degrees(
             BigDecimal("360") - hour_angle_degrees
           ).degrees

--- a/lib/astronoby/coordinates/horizontal.rb
+++ b/lib/astronoby/coordinates/horizontal.rb
@@ -21,13 +21,13 @@ module Astronoby
         t0 = @altitude.sin * @latitude.sin +
           @altitude.cos * @latitude.cos * @azimuth.cos
 
-        declination = Astronoby::Angle.as_radians(Math.asin(t0))
+        declination = Astronoby::Angle.asin(t0)
 
         t1 = @altitude.sin -
           @latitude.sin * declination.sin
 
-        hour_angle_degrees = Astronoby::Angle.as_radians(
-          Math.acos(t1 / (@latitude.cos * declination.cos))
+        hour_angle_degrees = Astronoby::Angle.acos(
+          t1 / (@latitude.cos * declination.cos)
         ).degrees
 
         if @azimuth.sin.positive?

--- a/lib/astronoby/nutation.rb
+++ b/lib/astronoby/nutation.rb
@@ -25,7 +25,7 @@ module Astronoby
         0,
         0,
         (
-          -17.2 * Math.sin(moon_ascending_node_longitude.radians) -
+          -17.2 * moon_ascending_node_longitude.sin -
           1.3 * Math.sin(2 * sun_mean_longitude.radians)
         )
       )
@@ -36,7 +36,7 @@ module Astronoby
         0,
         0,
         (
-          9.2 * Math.cos(moon_ascending_node_longitude.radians) +
+          9.2 * moon_ascending_node_longitude.cos +
           0.5 * Math.cos(2 * sun_mean_longitude.radians)
         )
       )

--- a/lib/astronoby/precession.rb
+++ b/lib/astronoby/precession.rb
@@ -35,9 +35,9 @@ module Astronoby
         right_ascension: Astronoby::Util::Trigonometry.adjustement_for_arctangent(
           Astronoby::Angle.as_radians(w[1]),
           Astronoby::Angle.as_radians(w[0]),
-          Astronoby::Angle.as_radians(Math.atan(w[1] / w[0]))
+          Astronoby::Angle.atan(w[1] / w[0])
         ),
-        declination: Astronoby::Angle.as_radians(Math.asin(w[2])),
+        declination: Astronoby::Angle.asin(w[2]),
         epoch: @epoch
       )
     end

--- a/lib/astronoby/precession.rb
+++ b/lib/astronoby/precession.rb
@@ -19,15 +19,13 @@ module Astronoby
     #  Edition: Cambridge University Press
     #  Chapter: 34 - Precession
     def precess
-      right_ascension = @coordinates.right_ascension.radians
-      declination = @coordinates.declination.radians
       matrix_a = matrix_for_epoch(@coordinates.epoch)
       matrix_b = matrix_for_epoch(@epoch).transpose
 
       vector = Vector[
-        Math.cos(right_ascension) * Math.cos(declination),
-        Math.sin(right_ascension) * Math.cos(declination),
-        Math.sin(declination)
+        @coordinates.right_ascension.cos * @coordinates.declination.cos,
+        @coordinates.right_ascension.sin * @coordinates.declination.cos,
+        @coordinates.declination.sin
       ]
 
       s = matrix_a * vector
@@ -51,22 +49,22 @@ module Astronoby
         Astronoby::Epoch::DAYS_PER_JULIAN_CENTURY
       )
 
-      ζ = Astronoby::Angle.as_degrees(
+      zeta = Astronoby::Angle.as_degrees(
         0.6406161 * t + 0.0000839 * t * t + 0.000005 * t * t * t
-      ).radians
+      )
       z = Astronoby::Angle.as_degrees(
         0.6406161 * t + 0.0003041 * t * t + 0.0000051 * t * t * t
-      ).radians
-      θ = Astronoby::Angle.as_degrees(
+      )
+      theta = Astronoby::Angle.as_degrees(
         0.5567530 * t - 0.0001185 * t * t - 0.0000116 * t * t * t
-      ).radians
+      )
 
-      cx = Math.cos(ζ)
-      sx = Math.sin(ζ)
-      cz = Math.cos(z)
-      sz = Math.sin(z)
-      ct = Math.cos(θ)
-      st = Math.sin(θ)
+      cx = zeta.cos
+      sx = zeta.sin
+      cz = z.cos
+      sz = z.sin
+      ct = theta.cos
+      st = theta.sin
 
       Matrix[
         [

--- a/lib/astronoby/refraction.rb
+++ b/lib/astronoby/refraction.rb
@@ -54,9 +54,7 @@ module Astronoby
 
       Astronoby::Coordinates::Horizontal.new(
         azimuth: @coordinates.azimuth,
-        altitude: Astronoby::Angle.as_degrees(
-          @coordinates.altitude.degrees + refraction_angle.degrees
-        ),
+        altitude: @coordinates.altitude + refraction_angle,
         latitude: @coordinates.latitude,
         longitude: @coordinates.longitude
       )

--- a/lib/astronoby/refraction.rb
+++ b/lib/astronoby/refraction.rb
@@ -32,7 +32,7 @@ module Astronoby
           zenith_angle = Astronoby::Angle.as_degrees(
             90 - @coordinates.altitude.degrees
           )
-          0.00452 * @pressure * Math.tan(zenith_angle.radians) / (273 + @temperature)
+          0.00452 * @pressure * zenith_angle.tan / (273 + @temperature)
         else
           (
             @pressure *

--- a/lib/astronoby/true_obliquity.rb
+++ b/lib/astronoby/true_obliquity.rb
@@ -10,11 +10,7 @@ module Astronoby
       mean_obliquity = Astronoby::MeanObliquity.for_epoch(epoch)
       nutation = Astronoby::Nutation.for_obliquity_of_the_ecliptic(epoch: epoch)
 
-      new(
-        Astronoby::Angle.as_degrees(
-          mean_obliquity.value.degrees + nutation.degrees
-        )
-      )
+      new(mean_obliquity.value + nutation)
     end
 
     def value

--- a/spec/astronoby/angle_spec.rb
+++ b/spec/astronoby/angle_spec.rb
@@ -20,6 +20,51 @@ RSpec.describe Astronoby::Angle do
     end
   end
 
+  describe "::asin" do
+    it "returns an Angle object" do
+      expect(described_class.asin(1)).to be_a(described_class)
+    end
+
+    it "initializes an angle with the inverse sine of a ratio" do
+      ratio = 0.5
+      angle = described_class.asin(ratio)
+      precision = 10**-described_class::PRECISION
+      radians = described_class::PI / 6
+
+      expect(angle.radians).to be_within(precision).of(radians)
+    end
+  end
+
+  describe "::acos" do
+    it "returns an Angle object" do
+      expect(described_class.acos(0.5)).to be_a(described_class)
+    end
+
+    it "initializes an angle with the inverse sine of a ratio" do
+      ratio = 0.5
+      angle = described_class.acos(ratio)
+      precision = 10**-described_class::PRECISION
+      radians = described_class::PI / 3
+
+      expect(angle.radians).to be_within(precision).of(radians)
+    end
+  end
+
+  describe "::atan" do
+    it "returns an Angle object" do
+      expect(described_class.atan(1)).to be_a(described_class)
+    end
+
+    it "initializes an angle with the inverse sine of a ratio" do
+      ratio = 1
+      angle = described_class.atan(ratio)
+      precision = 10**-described_class::PRECISION
+      radians = described_class::PI / 4
+
+      expect(angle.radians).to be_within(precision).of(radians)
+    end
+  end
+
   describe "#radians" do
     it "returns the angle value in radian unit" do
       radians = described_class.new(described_class::PI).radians

--- a/spec/astronoby/angle_spec.rb
+++ b/spec/astronoby/angle_spec.rb
@@ -104,6 +104,17 @@ RSpec.describe Astronoby::Angle do
     end
   end
 
+  describe "#-" do
+    it "returns a new angle with a value of the two angles substracted" do
+      angle_1 = described_class.as_radians(described_class::PI)
+      angle_2 = described_class.as_degrees(45)
+
+      new_angle = angle_1 - angle_2
+
+      expect(new_angle.degrees).to eq 135
+    end
+  end
+
   describe "#str" do
     it "returns a String" do
       angle = described_class.as_degrees(180)

--- a/spec/astronoby/angle_spec.rb
+++ b/spec/astronoby/angle_spec.rb
@@ -93,6 +93,17 @@ RSpec.describe Astronoby::Angle do
     end
   end
 
+  describe "#+" do
+    it "returns a new angle with a value of the two angles added" do
+      angle_1 = described_class.as_radians(described_class::PI)
+      angle_2 = described_class.as_degrees(45)
+
+      new_angle = angle_1 + angle_2
+
+      expect(new_angle.degrees).to eq 225
+    end
+  end
+
   describe "#str" do
     it "returns a String" do
       angle = described_class.as_degrees(180)

--- a/spec/astronoby/angle_spec.rb
+++ b/spec/astronoby/angle_spec.rb
@@ -115,6 +115,39 @@ RSpec.describe Astronoby::Angle do
     end
   end
 
+  describe "#sin" do
+    it "returns the sine value of the angle" do
+      radians = described_class::PI / 6
+      angle = described_class.as_radians(radians)
+
+      sine = angle.sin.ceil(described_class::PRECISION)
+
+      expect(sine).to eq 0.5
+    end
+  end
+
+  describe "#cos" do
+    it "returns the cosine value of the angle" do
+      radians = described_class::PI / 3
+      angle = described_class.as_radians(radians)
+
+      cosine = angle.cos.ceil(described_class::PRECISION)
+
+      expect(cosine).to eq 0.5
+    end
+  end
+
+  describe "#tan" do
+    it "returns the tangent value of the angle" do
+      radians = described_class::PI / 4
+      angle = described_class.as_radians(radians)
+
+      tangent = angle.tan.ceil(described_class::PRECISION)
+
+      expect(tangent).to eq 1
+    end
+  end
+
   describe "#str" do
     it "returns a String" do
       angle = described_class.as_degrees(180)


### PR DESCRIPTION
This introduces several arithmetic functions in `Angle` to increase readability and developer experience.

### Instance methods

- `Angle#+`: adds two angles' values and returns an angle
- `Angle#-`: subtracts two angles' values and returns an angle
- `Angle#sin`: returns the numeric value (ratio) of the sine of the angle
- `Angle#cos`: returns the numeric value (ratio) of the cosine of the angle
- `Angle#tan`: returns the numeric value (ratio) of the tangent of the angle

###Class methods

- `Angle::asin`: returns a new angle from the radians of a inverse sine ratio
- `Angle::acos`: returns a new angle from the radians of a inverse cosine ratio
- `Angle::atan`: returns a new angle from the radians of a inverse tangent ratio

### Examples

```rb
angle_1 = Astronoby::Angle.as_radians(described_class::PI)
angle_2 = Astronoby::Angle.as_degrees(45)
new_angle = angle_1 + angle_2
new_angle.degrees
# => 225

Astronoby::Angle.as_radians(Math::PI / 6).sin
# => ~ 0.5

angle = Astronoby::Angle.atan(1)
angle.radians
# => ~ π÷4
```