### PR TITLE
Remove unnecessary mentions of `Astronoby::`

### DIFF
--- a/lib/astronoby/aberration.rb
+++ b/lib/astronoby/aberration.rb
@@ -19,19 +19,19 @@ module Astronoby
     #  Edition: Cambridge University Press
     #  Chapter: 36 - Aberration
     def apply
-      delta_longitude = Astronoby::Angle.as_degrees(
+      delta_longitude = Angle.as_degrees(
         -20.5 * (
           @sun_longitude - @coordinates.longitude
         ).cos / @coordinates.latitude.cos / 3600
       )
 
-      delta_latitude = Astronoby::Angle.as_degrees(
+      delta_latitude = Angle.as_degrees(
         -20.5 *
         (@sun_longitude - @coordinates.longitude).sin *
         @coordinates.latitude.sin / 3600
       )
 
-      Astronoby::Coordinates::Ecliptic.new(
+      Coordinates::Ecliptic.new(
         latitude: @coordinates.latitude + delta_latitude,
         longitude: @coordinates.longitude + delta_longitude
       )

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -56,25 +56,25 @@ module Astronoby
       Epoch::DEFAULT_EPOCH - @epoch
     end
 
-    def t
-      @t ||= (@epoch - Epoch::J1900) / Epoch::DAYS_PER_JULIAN_CENTURY
+    def centuries
+      @centuries ||= (@epoch - Epoch::J1900) / Epoch::DAYS_PER_JULIAN_CENTURY
     end
 
     def longitude_at_base_epoch
       Angle.as_degrees(
-        (279.6966778 + 36000.76892 * t + 0.0003025 * t * t) % 360
+        (279.6966778 + 36000.76892 * centuries + 0.0003025 * centuries**2) % 360
       )
     end
 
     def longitude_at_perigee
       Angle.as_degrees(
-        (281.2208444 + 1.719175 * t + 0.000452778 * t * t) % 360
+        (281.2208444 + 1.719175 * centuries + 0.000452778 * centuries**2) % 360
       )
     end
 
     def orbital_eccentricity
       Angle.as_degrees(
-        (0.01675104 - 0.0000418 * t - 0.000000126 * t * t) % 360
+        (0.01675104 - 0.0000418 * centuries - 0.000000126 * centuries**2) % 360
       )
     end
   end

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -22,7 +22,7 @@ module Astronoby
     end
 
     def horizontal_coordinates(latitude:, longitude:)
-      time = Astronoby::Epoch.to_utc(@epoch)
+      time = Epoch.to_utc(@epoch)
 
       ecliptic_coordinates
         .to_equatorial(epoch: @epoch)
@@ -38,7 +38,7 @@ module Astronoby
     end
 
     def true_anomaly
-      eccentric_anomaly = Astronoby::Util::Astrodynamics.eccentric_anomaly_newton_raphson(
+      eccentric_anomaly = Util::Astrodynamics.eccentric_anomaly_newton_raphson(
         mean_anomaly,
         orbital_eccentricity.degrees,
         2e-06,
@@ -49,9 +49,7 @@ module Astronoby
         (1 + orbital_eccentricity.degrees) / (1 - orbital_eccentricity.degrees)
       ) * Math.tan(eccentric_anomaly.radians / 2)
 
-      Astronoby::Angle.as_degrees(
-        (Astronoby::Angle.atan(tan).degrees * 2) % 360
-      )
+      Angle.as_degrees((Angle.atan(tan).degrees * 2) % 360)
     end
 
     def days_since_epoch
@@ -59,24 +57,23 @@ module Astronoby
     end
 
     def t
-      @t ||=
-        (@epoch - Astronoby::Epoch::J1900) / Astronoby::Epoch::DAYS_PER_JULIAN_CENTURY
+      @t ||= (@epoch - Epoch::J1900) / Epoch::DAYS_PER_JULIAN_CENTURY
     end
 
     def longitude_at_base_epoch
-      Astronoby::Angle.as_degrees(
+      Angle.as_degrees(
         (279.6966778 + 36000.76892 * t + 0.0003025 * t * t) % 360
       )
     end
 
     def longitude_at_perigee
-      Astronoby::Angle.as_degrees(
+      Angle.as_degrees(
         (281.2208444 + 1.719175 * t + 0.000452778 * t * t) % 360
       )
     end
 
     def orbital_eccentricity
-      Astronoby::Angle.as_degrees(
+      Angle.as_degrees(
         (0.01675104 - 0.0000418 * t - 0.000000126 * t * t) % 360
       )
     end

--- a/lib/astronoby/body.rb
+++ b/lib/astronoby/body.rb
@@ -19,11 +19,7 @@ module Astronoby
         @equatorial_coordinates.right_ascension.hours - h2_component.degrees
       rising_lst -= 24 if rising_lst > 24
 
-      Astronoby::Util::Time.lst_to_ut(
-        date: date,
-        longitude: longitude,
-        lst: rising_lst
-      )
+      Util::Time.lst_to_ut(date: date, longitude: longitude, lst: rising_lst)
     end
 
     # Source:
@@ -35,7 +31,7 @@ module Astronoby
       ar = azimuth_component(latitude: latitude)
       return nil if ar >= 1
 
-      Astronoby::Angle.acos(ar)
+      Angle.acos(ar)
     end
 
     # Source:
@@ -50,11 +46,7 @@ module Astronoby
       setting_lst = @equatorial_coordinates.right_ascension.hours + h2_component.degrees
       setting_lst -= 24 if setting_lst > 24
 
-      Astronoby::Util::Time.lst_to_ut(
-        date: date,
-        longitude: longitude,
-        lst: setting_lst
-      )
+      Util::Time.lst_to_ut(date: date, longitude: longitude, lst: setting_lst)
     end
 
     # Source:
@@ -66,7 +58,7 @@ module Astronoby
       rising_az = rising_azimuth(latitude: latitude)
       return nil if rising_az.nil?
 
-      Astronoby::Angle.as_degrees(360 - rising_az.degrees)
+      Angle.as_degrees(360 - rising_az.degrees)
     end
 
     private
@@ -82,7 +74,7 @@ module Astronoby
       h1 = latitude.tan * @equatorial_coordinates.declination.tan
       return nil if h1.abs > 1
 
-      Astronoby::Angle.as_radians(Math.acos(-h1) / 15.0)
+      Angle.as_radians(Math.acos(-h1) / 15.0)
     end
   end
 end

--- a/lib/astronoby/coordinates/ecliptic.rb
+++ b/lib/astronoby/coordinates/ecliptic.rb
@@ -16,18 +16,17 @@ module Astronoby
       #  Edition: MIT Press
       #  Chapter: 4 - Orbits and Coordinate Systems
       def to_equatorial(epoch:)
-        mean_obliquity = Astronoby::MeanObliquity.for_epoch(epoch)
+        mean_obliquity = MeanObliquity.for_epoch(epoch)
         obliquity = mean_obliquity.value
 
-        y = Astronoby::Angle.as_radians(
+        y = Angle.as_radians(
           @longitude.sin * obliquity.cos - @latitude.tan * obliquity.sin
         )
-        x = Astronoby::Angle.as_radians(@longitude.cos)
-        r = Astronoby::Angle.atan(y.radians / x.radians)
-        right_ascension = Astronoby::Util::Trigonometry
-          .adjustement_for_arctangent(y, x, r)
+        x = Angle.as_radians(@longitude.cos)
+        r = Angle.atan(y.radians / x.radians)
+        right_ascension = Util::Trigonometry.adjustement_for_arctangent(y, x, r)
 
-        declination = Astronoby::Angle.asin(
+        declination = Angle.asin(
           @latitude.sin * obliquity.cos +
           @latitude.cos * obliquity.sin * @longitude.sin
         )

--- a/lib/astronoby/coordinates/equatorial.rb
+++ b/lib/astronoby/coordinates/equatorial.rb
@@ -9,7 +9,7 @@ module Astronoby
         declination:,
         right_ascension:,
         hour_angle: nil,
-        epoch: Astronoby::Epoch::DEFAULT_EPOCH
+        epoch: Epoch::DEFAULT_EPOCH
       )
         @right_ascension = right_ascension
         @declination = declination
@@ -18,7 +18,7 @@ module Astronoby
       end
 
       def compute_hour_angle(time:, longitude:)
-        lst = Astronoby::Util::Time.local_sidereal_time(
+        lst = Util::Time.local_sidereal_time(
           time: time,
           longitude: longitude
         )
@@ -26,21 +26,21 @@ module Astronoby
         ha = (lst - @right_ascension.hours)
         ha += 24 if ha.negative?
 
-        Astronoby::Angle.as_hours(ha)
+        Angle.as_hours(ha)
       end
 
       def to_horizontal(time:, latitude:, longitude:)
         ha = @hour_angle || compute_hour_angle(time: time, longitude: longitude)
         t0 = @declination.sin * latitude.sin +
           @declination.cos * latitude.cos * ha.cos
-        altitude = Astronoby::Angle.asin(t0)
+        altitude = Angle.asin(t0)
 
         t1 = @declination.sin - latitude.sin * altitude.sin
         t2 = t1 / (latitude.cos * altitude.cos)
-        azimuth = Astronoby::Angle.acos(t2)
+        azimuth = Angle.acos(t2)
 
         if ha.sin.positive?
-          azimuth = Astronoby::Angle.as_degrees(BigDecimal("360") - azimuth.degrees)
+          azimuth = Angle.as_degrees(BigDecimal("360") - azimuth.degrees)
         end
 
         Horizontal.new(
@@ -57,18 +57,18 @@ module Astronoby
       #  Edition: MIT Press
       #  Chapter: 4 - Orbits and Coordinate Systems
       def to_ecliptic(epoch:)
-        mean_obliquity = Astronoby::MeanObliquity.for_epoch(epoch)
+        mean_obliquity = MeanObliquity.for_epoch(epoch)
         obliquity = mean_obliquity.value
 
-        y = Astronoby::Angle.as_radians(
+        y = Angle.as_radians(
           @right_ascension.sin * obliquity.cos +
             @declination.tan * obliquity.sin
         )
-        x = Astronoby::Angle.as_radians(@right_ascension.cos)
-        r = Astronoby::Angle.atan(y.radians / x.radians)
-        longitude = Astronoby::Util::Trigonometry.adjustement_for_arctangent(y, x, r)
+        x = Angle.as_radians(@right_ascension.cos)
+        r = Angle.atan(y.radians / x.radians)
+        longitude = Util::Trigonometry.adjustement_for_arctangent(y, x, r)
 
-        latitude = Astronoby::Angle.asin(
+        latitude = Angle.asin(
           @declination.sin * obliquity.cos -
           @declination.cos * obliquity.sin * @right_ascension.sin
         )
@@ -80,7 +80,7 @@ module Astronoby
       end
 
       def to_epoch(epoch)
-        Astronoby::Precession.for_equatorial_coordinates(
+        Precession.for_equatorial_coordinates(
           coordinates: self,
           epoch: epoch
         )

--- a/lib/astronoby/coordinates/horizontal.rb
+++ b/lib/astronoby/coordinates/horizontal.rb
@@ -21,28 +21,27 @@ module Astronoby
         t0 = @altitude.sin * @latitude.sin +
           @altitude.cos * @latitude.cos * @azimuth.cos
 
-        declination = Astronoby::Angle.asin(t0)
+        declination = Angle.asin(t0)
 
-        t1 = @altitude.sin -
-          @latitude.sin * declination.sin
+        t1 = @altitude.sin - @latitude.sin * declination.sin
 
-        hour_angle_degrees = Astronoby::Angle.acos(
-          t1 / (@latitude.cos * declination.cos)
-        ).degrees
+        hour_angle_degrees = Angle
+          .acos(t1 / (@latitude.cos * declination.cos))
+          .degrees
 
         if @azimuth.sin.positive?
-          hour_angle_degrees = Astronoby::Angle.as_degrees(
-            BigDecimal("360") - hour_angle_degrees
-          ).degrees
+          hour_angle_degrees = Angle
+            .as_degrees(BigDecimal("360") - hour_angle_degrees)
+            .degrees
         end
 
-        hour_angle_hours = Astronoby::Angle.as_degrees(hour_angle_degrees).hours
-        right_ascension_decimal = Astronoby::Util::Time.local_sidereal_time(
+        hour_angle_hours = Angle.as_degrees(hour_angle_degrees).hours
+        right_ascension_decimal = Util::Time.local_sidereal_time(
           time: time,
           longitude: @longitude
         ) - hour_angle_hours
         right_ascension_decimal += 24 if right_ascension_decimal.negative?
-        right_ascension = Astronoby::Angle.as_hours(right_ascension_decimal)
+        right_ascension = Angle.as_hours(right_ascension_decimal)
 
         Equatorial.new(
           right_ascension: right_ascension,

--- a/lib/astronoby/mean_obliquity.rb
+++ b/lib/astronoby/mean_obliquity.rb
@@ -8,7 +8,7 @@ module Astronoby
     #  IAU resolution in 2006 in favor of the P03 astronomical model
     #  The Astronomical Almanac for 2010
 
-    EPOCH_OF_REFERENCE = Astronoby::Epoch::DEFAULT_EPOCH
+    EPOCH_OF_REFERENCE = Epoch::DEFAULT_EPOCH
     OBLIQUITY_OF_REFERENCE = 23.4392794
 
     def initialize(obliquity)
@@ -20,12 +20,10 @@ module Astronoby
         return new(obliquity_of_reference)
       end
 
-      t = (epoch - EPOCH_OF_REFERENCE)./(
-        Astronoby::Epoch::DAYS_PER_JULIAN_CENTURY
-      )
+      t = (epoch - EPOCH_OF_REFERENCE) / Epoch::DAYS_PER_JULIAN_CENTURY
 
       new(
-        Astronoby::Angle.as_degrees(
+        Angle.as_degrees(
           obliquity_of_reference.degrees - (
             46.815 * t -
             0.0006 * t * t +
@@ -36,7 +34,7 @@ module Astronoby
     end
 
     def self.obliquity_of_reference
-      Astronoby::Angle.as_dms(23, 26, 21.45)
+      Angle.as_dms(23, 26, 21.45)
     end
 
     def value

--- a/lib/astronoby/nutation.rb
+++ b/lib/astronoby/nutation.rb
@@ -49,18 +49,22 @@ module Astronoby
     end
 
     def sun_mean_longitude
-      Angle.as_degrees((279.6967 + 360.0 * (a - a.to_i)) % 360)
+      Angle.as_degrees(
+        (279.6967 + 360.0 * (centuries_a - centuries_a.to_i)) % 360
+      )
     end
 
     def moon_ascending_node_longitude
-      Angle.as_degrees((259.1833 - 360.0 * (b - b.to_i)) % 360)
+      Angle.as_degrees(
+        (259.1833 - 360.0 * (centuries_b - centuries_b.to_i)) % 360
+      )
     end
 
-    def a
+    def centuries_a
       100.002136 * julian_centuries
     end
 
-    def b
+    def centuries_b
       5.372617 * julian_centuries
     end
   end

--- a/lib/astronoby/nutation.rb
+++ b/lib/astronoby/nutation.rb
@@ -21,7 +21,7 @@ module Astronoby
     end
 
     def for_ecliptic_longitude
-      Astronoby::Angle.as_dms(
+      Angle.as_dms(
         0,
         0,
         (
@@ -32,7 +32,7 @@ module Astronoby
     end
 
     def for_obliquity_of_the_ecliptic
-      Astronoby::Angle.as_dms(
+      Angle.as_dms(
         0,
         0,
         (
@@ -45,17 +45,15 @@ module Astronoby
     private
 
     def julian_centuries
-      (@epoch - Astronoby::Epoch::J1900)./(
-        Astronoby::Epoch::DAYS_PER_JULIAN_CENTURY
-      )
+      (@epoch - Epoch::J1900) / Epoch::DAYS_PER_JULIAN_CENTURY
     end
 
     def sun_mean_longitude
-      Astronoby::Angle.as_degrees((279.6967 + 360.0 * (a - a.to_i)) % 360)
+      Angle.as_degrees((279.6967 + 360.0 * (a - a.to_i)) % 360)
     end
 
     def moon_ascending_node_longitude
-      Astronoby::Angle.as_degrees((259.1833 - 360.0 * (b - b.to_i)) % 360)
+      Angle.as_degrees((259.1833 - 360.0 * (b - b.to_i)) % 360)
     end
 
     def a

--- a/lib/astronoby/precession.rb
+++ b/lib/astronoby/precession.rb
@@ -31,13 +31,13 @@ module Astronoby
       s = matrix_a * vector
       w = matrix_b * s
 
-      Astronoby::Coordinates::Equatorial.new(
-        right_ascension: Astronoby::Util::Trigonometry.adjustement_for_arctangent(
-          Astronoby::Angle.as_radians(w[1]),
-          Astronoby::Angle.as_radians(w[0]),
-          Astronoby::Angle.atan(w[1] / w[0])
+      Coordinates::Equatorial.new(
+        right_ascension: Util::Trigonometry.adjustement_for_arctangent(
+          Angle.as_radians(w[1]),
+          Angle.as_radians(w[0]),
+          Angle.atan(w[1] / w[0])
         ),
-        declination: Astronoby::Angle.asin(w[2]),
+        declination: Angle.asin(w[2]),
         epoch: @epoch
       )
     end
@@ -45,17 +45,15 @@ module Astronoby
     private
 
     def matrix_for_epoch(epoch)
-      t = (epoch - Astronoby::Epoch::DEFAULT_EPOCH)./(
-        Astronoby::Epoch::DAYS_PER_JULIAN_CENTURY
-      )
+      t = (epoch - Epoch::DEFAULT_EPOCH) / Epoch::DAYS_PER_JULIAN_CENTURY
 
-      zeta = Astronoby::Angle.as_degrees(
+      zeta = Angle.as_degrees(
         0.6406161 * t + 0.0000839 * t * t + 0.000005 * t * t * t
       )
-      z = Astronoby::Angle.as_degrees(
+      z = Angle.as_degrees(
         0.6406161 * t + 0.0003041 * t * t + 0.0000051 * t * t * t
       )
-      theta = Astronoby::Angle.as_degrees(
+      theta = Angle.as_degrees(
         0.5567530 * t - 0.0001185 * t * t - 0.0000116 * t * t * t
       )
 

--- a/lib/astronoby/refraction.rb
+++ b/lib/astronoby/refraction.rb
@@ -27,11 +27,9 @@ module Astronoby
     def refract
       altitude_in_degrees = @coordinates.altitude.degrees
 
-      refraction_angle = Astronoby::Angle.as_degrees(
+      refraction_angle = Angle.as_degrees(
         if altitude_in_degrees > 15
-          zenith_angle = Astronoby::Angle.as_degrees(
-            90 - @coordinates.altitude.degrees
-          )
+          zenith_angle = Angle.as_degrees(90 - @coordinates.altitude.degrees)
           0.00452 * @pressure * zenith_angle.tan / (273 + @temperature)
         else
           (
@@ -52,7 +50,7 @@ module Astronoby
         end
       )
 
-      Astronoby::Coordinates::Horizontal.new(
+      Coordinates::Horizontal.new(
         azimuth: @coordinates.azimuth,
         altitude: @coordinates.altitude + refraction_angle,
         latitude: @coordinates.latitude,

--- a/lib/astronoby/true_obliquity.rb
+++ b/lib/astronoby/true_obliquity.rb
@@ -7,8 +7,8 @@ module Astronoby
     end
 
     def self.for_epoch(epoch)
-      mean_obliquity = Astronoby::MeanObliquity.for_epoch(epoch)
-      nutation = Astronoby::Nutation.for_obliquity_of_the_ecliptic(epoch: epoch)
+      mean_obliquity = MeanObliquity.for_epoch(epoch)
+      nutation = Nutation.for_obliquity_of_the_ecliptic(epoch: epoch)
 
       new(mean_obliquity.value + nutation)
     end

--- a/lib/astronoby/util/astrodynamics.rb
+++ b/lib/astronoby/util/astrodynamics.rb
@@ -19,7 +19,7 @@ module Astronoby
         )
           previous_solution = solution_on_previous_interation&.radians
 
-          solution = if current_iteration == 0
+          solution = if previous_solution.nil?
             if orbital_eccentricity <= 0.75
               mean_anomaly.radians
             else
@@ -39,7 +39,7 @@ module Astronoby
 
           if current_iteration >= maximum_iteration_count ||
               (
-                solution_on_previous_interation &&
+                previous_solution &&
                 (solution - previous_solution).abs <= precision
               )
             return Angle.as_radians(solution)

--- a/lib/astronoby/util/astrodynamics.rb
+++ b/lib/astronoby/util/astrodynamics.rb
@@ -42,7 +42,7 @@ module Astronoby
                 solution_on_previous_interation &&
                 (solution - previous_solution).abs <= precision
               )
-            return Astronoby::Angle.as_radians(solution)
+            return Angle.as_radians(solution)
           end
 
           eccentric_anomaly_newton_raphson(
@@ -51,7 +51,7 @@ module Astronoby
             precision,
             maximum_iteration_count,
             current_iteration + 1,
-            Astronoby::Angle.as_radians(solution)
+            Angle.as_radians(solution)
           )
         end
       end

--- a/lib/astronoby/util/time.rb
+++ b/lib/astronoby/util/time.rb
@@ -11,10 +11,7 @@ module Astronoby
         #  Chapter: 12 - Conversion of UT to Greenwich sidereal time (GST)
         def ut_to_gmst(universal_time)
           julian_day = universal_time.to_date.ajd
-          t = (julian_day - Astronoby::Epoch::J2000)./(
-            Astronoby::Epoch::DAYS_PER_JULIAN_CENTURY
-          )
-
+          t = (julian_day - Epoch::J2000) / Epoch::DAYS_PER_JULIAN_CENTURY
           t0 = (
             (BigDecimal("6.697374558") +
             (BigDecimal("2400.051336") * t) +
@@ -41,9 +38,7 @@ module Astronoby
           jd0 = ::DateTime.new(date.year, 1, 1, 0, 0, 0).ajd - 1
           days_into_the_year = julian_day - jd0
 
-          t = (jd0 - Astronoby::Epoch::J1900)./(
-            Astronoby::Epoch::DAYS_PER_JULIAN_CENTURY
-          )
+          t = (jd0 - Epoch::J1900) / Epoch::DAYS_PER_JULIAN_CENTURY
           r = BigDecimal("6.6460656") +
             BigDecimal("2400.051262") * t +
             BigDecimal("0.00002581") * t * t

--- a/lib/astronoby/util/trigonometry.rb
+++ b/lib/astronoby/util/trigonometry.rb
@@ -15,10 +15,10 @@ module Astronoby
           return angle if y.degrees.positive? && x.degrees.positive?
 
           if y.degrees.negative? && x.degrees.positive?
-            return Astronoby::Angle.as_degrees(angle.degrees + 360)
+            return Angle.as_degrees(angle.degrees + 360)
           end
 
-          Astronoby::Angle.as_degrees(angle.degrees + 180)
+          Angle.as_degrees(angle.degrees + 180)
         end
       end
     end


### PR DESCRIPTION
In `lib/`, mentioning `Astronoby` module is not necessary in a majority of cases.

This cleans up the code to make it more readable.

Some code offenses are also fixed.