### PR TITLE
Normalize angles to a single circle

### DIFF
--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -8,6 +8,8 @@ module Astronoby
     PI = BigMath.PI(PRECISION)
     PI_IN_DEGREES = BigDecimal("180")
 
+    FULL_CIRCLE_IN_RADIANS = (2 * PI)
+
     RADIAN_PER_HOUR = PI / BigDecimal("12")
     MINUTES_PER_DEGREE = BigDecimal("60")
     MINUTES_PER_HOUR = BigDecimal("60")
@@ -22,17 +24,18 @@ module Astronoby
       end
 
       def as_radians(radians)
-        new(radians)
+        normalized_radians = radians.remainder(FULL_CIRCLE_IN_RADIANS)
+        new(normalized_radians)
       end
 
       def as_degrees(degrees)
         radians = degrees / PI_IN_DEGREES * PI
-        new(radians)
+        as_radians(radians)
       end
 
       def as_hours(hours)
         radians = hours * RADIAN_PER_HOUR
-        new(radians)
+        as_radians(radians)
       end
 
       def as_hms(hour, minute, second)

--- a/spec/astronoby/angle_spec.rb
+++ b/spec/astronoby/angle_spec.rb
@@ -20,17 +20,47 @@ RSpec.describe Astronoby::Angle do
       expect(described_class.as_radians(described_class::PI))
         .to be_a(described_class)
     end
+
+    it "normalizes the angle" do
+      expect(described_class.as_radians(2 * described_class::PI).radians)
+        .to eq 0
+
+      expect(described_class.as_radians(3 * described_class::PI).radians)
+        .to eq described_class::PI
+
+      expect(described_class.as_radians(-5 * described_class::PI).radians)
+        .to eq(-described_class::PI)
+
+      expect(described_class.as_radians(described_class::PI / 2).radians)
+        .to eq described_class::PI / 2
+    end
   end
 
   describe "::as_degrees" do
     it "returns an Angle object" do
       expect(described_class.as_degrees(180)).to be_a(described_class)
     end
+
+    it "normalizes the angle" do
+      expect(described_class.as_degrees(360).degrees.round).to eq 0
+      expect(described_class.as_degrees(365).degrees.round).to eq 5
+      expect(described_class.as_degrees(-365).degrees.round).to eq(-5)
+      expect(described_class.as_degrees(70).degrees.round).to eq 70
+      expect(described_class.as_degrees(-70).degrees.round).to eq(-70)
+    end
   end
 
   describe "::as_hours" do
     it "returns an Angle object" do
       expect(described_class.as_hours(23)).to be_a(described_class)
+    end
+
+    it "normalizes the angle" do
+      expect(described_class.as_hours(24).hours.round).to eq 0
+      expect(described_class.as_hours(26).hours.round).to eq 2
+      expect(described_class.as_hours(-26).hours.round).to eq(-2)
+      expect(described_class.as_hours(23).hours.round).to eq 23
+      expect(described_class.as_hours(-23).hours.round).to eq(-23)
     end
   end
 

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Astronoby::Sun do
       ecliptic_coordinates = described_class.new(epoch: epoch).ecliptic_coordinates
 
       expect(ecliptic_coordinates.longitude.degrees.to_f).to(
-        eq(316.57267134069514)
+        eq(316.5726713406949)
       )
     end
 
@@ -38,7 +38,7 @@ RSpec.describe Astronoby::Sun do
       ecliptic_coordinates = described_class.new(epoch: epoch).ecliptic_coordinates
 
       expect(ecliptic_coordinates.longitude.degrees.to_f).to(
-        eq(137.36484079771108)
+        eq(137.36484079770798)
       )
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Astronoby::Sun do
       ecliptic_coordinates = described_class.new(epoch: epoch).ecliptic_coordinates
 
       expect(ecliptic_coordinates.longitude.degrees.to_f).to(
-        eq(45.92185191445215)
+        eq(45.92185191445673)
       )
     end
 


### PR DESCRIPTION
Before, it was possible to instantiate degrees with values above a full circle, like 365 degrees, 3×π or 25 hours.

While this is mathematically acceptable, it makes it ambiguous when we will add the ability to compare angles between each other.

For example, on a single circle, 3×π is a smaller angle than π÷2.

Without normalization, the angle's value is just a number that can go up and down to the infinity.

This introduces angle normalization, so that angles are always included in the following ranges (depending on their unit):
- [-2π, 2π] radians
- [0, 360] degrees
- [0, 24] hours

Fixes #19