### PR TITLE
Angle comparison

### DIFF
--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -4,6 +4,8 @@ require "bigdecimal/math"
 
 module Astronoby
   class Angle
+    include Comparable
+
     PRECISION = 14
     PI = BigMath.PI(PRECISION)
     PI_IN_DEGREES = BigDecimal("180")

--- a/spec/astronoby/angle_spec.rb
+++ b/spec/astronoby/angle_spec.rb
@@ -313,23 +313,47 @@ RSpec.describe Astronoby::Angle do
     end
   end
 
-  describe "#<=>" do
-    it "compares the two object values" do
-      angle1 = Astronoby::Angle.as_degrees(10)
-      angle2 = Astronoby::Angle.as_degrees(5)
-      angle3 = Astronoby::Angle.as_degrees(20)
+  describe "comparison" do
+    it "handles comparison of angles" do
+      angle = described_class.as_degrees(10)
+      same_angle = described_class.as_degrees(10)
+      greater_angle = described_class.as_radians(described_class::PI)
+      smaller_angle = described_class.as_degrees(5)
+      way_greater_angle = described_class.as_degrees(365)
+      negative_angle = described_class.as_radians(-described_class::PI)
 
-      expect(angle1 <=> Astronoby::Angle.as_degrees(10)).to eq 0
-      expect(angle1 <=> angle2).to be > 0
-      expect(angle1 <=> angle3).to be < 0
+      expect(angle == same_angle).to be true
+      expect(angle != same_angle).to be false
+      expect(angle > same_angle).to be false
+      expect(angle >= same_angle).to be true
+      expect(angle < same_angle).to be false
+      expect(angle <= same_angle).to be true
+
+      expect(angle < greater_angle).to be true
+      expect(angle == greater_angle).to be false
+      expect(angle != greater_angle).to be true
+      expect(angle > greater_angle).to be false
+
+      expect(angle < smaller_angle).to be false
+      expect(angle == smaller_angle).to be false
+      expect(angle != smaller_angle).to be true
+      expect(angle > smaller_angle).to be true
+
+      expect(angle < way_greater_angle).to be false
+      expect(angle == way_greater_angle).to be false
+      expect(angle != way_greater_angle).to be true
+      expect(angle > way_greater_angle).to be true
+
+      expect(angle < negative_angle).to be false
+      expect(angle == negative_angle).to be false
+      expect(angle != negative_angle).to be true
+      expect(angle > negative_angle).to be true
     end
 
-    context "when the two objects are different type" do
-      it "returns nil" do
-        angle = Astronoby::Angle.as_degrees(10)
+    it "doesn't support comparison of angles with other types" do
+      angle = Astronoby::Angle.as_degrees(10)
 
-        expect(angle <=> 10).to be_nil
-      end
+      expect(angle <=> 10).to be_nil
     end
   end
 


### PR DESCRIPTION
Before, it wasn't possible to compare angles between each other.

Now, we can use the comparison operations (`==`, `<`, `>`, `<=`, `>=`, `!=`, `<=>`) between two angles.

It is still not possible to compare an angle with on object of different type.

Fixed #18