### PR TITLE
release: Bump version to 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
-## [Unreleased]
+# Changelog
 
-## [0.0.1] - 2022-04-20
+## 0.1.0 - 2024-02-28
 
-- Add `Astronoby::Angle`
-- Support angles in degrees and radians
+### Features
+
+* Support angles in hours
+* Support coordinates
+  * `Astronoby::Coordinates::Horizontal`
+  * `Astronoby::Coordinates::Equatorial`
+  * `Astronoby::Coordinates::Ecliptic`
+* Add new body `Astronoby::Sun`
+* Add `Astronoby::Aberration`
+* Add `Astronoby::Epoch`
+* Add `Astronoby::MeanObliquity`
+* Add `Astronoby::TrueObliquity`
+* Add `Astronoby::Nutation`
+* Add `Astronoby::Precession`
+* Add `Astronoby::Refraction`
+* Add utils
+  * `Astronoby::Util::Astrodynamics`
+  * `Astronoby::Util::Time`
+  * `Astronoby::Util::Trigonometry`
+
+## 0.0.1 - 2022-04-20
+
+* Add `Astronoby::Angle`
+* Support angles in degrees and radians

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    astronoby (0.0.1)
+    astronoby (0.1.0)
       matrix (~> 0.4.2)
       rake (~> 13.0)
       rspec (~> 3.0)
@@ -21,7 +21,7 @@ GEM
       racc
     racc (1.7.0)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.1.0)
     regexp_parser (2.8.1)
     rexml (3.2.5)
     rspec (3.12.0)
@@ -33,10 +33,10 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
     rubocop (1.52.0)
       json (~> 2.3)
       parallel (~> 1.10)

--- a/lib/astronoby/version.rb
+++ b/lib/astronoby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Astronoby
-  VERSION = "0.0.1"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
Releasing the 0.1.0 version of the gem.

This is the first official release. Good practices and standards have not been respected so far, as I mainly added features and refactored the code with no concern with backward compatibility.

Now that the gem is going to be available on RubyGems.org, I aim to be better at this and enable potential users to use this gem safely.

## 0.1.0 - 2024-02-28

### Features

* Support angles in hours
* Support coordinates
  * `Astronoby::Coordinates::Horizontal`
  * `Astronoby::Coordinates::Equatorial`
  * `Astronoby::Coordinates::Ecliptic`
* Add new body `Astronoby::Sun`
* Add `Astronoby::Aberration`
* Add `Astronoby::Epoch`
* Add `Astronoby::MeanObliquity`
* Add `Astronoby::TrueObliquity`
* Add `Astronoby::Nutation`
* Add `Astronoby::Precession`
* Add `Astronoby::Refraction`
* Add utils
  * `Astronoby::Util::Astrodynamics`
  * `Astronoby::Util::Time`
  * `Astronoby::Util::Trigonometry`