### PR TITLE
Add Dependabot for Bundler and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "02:00"
+      timezone: "Etc/UTC"


### PR DESCRIPTION
This enabled Dependabot to run:
- daily for Bundler dependencies
- weekly for GitHub Actions