### PR TITLE
Add bundler-audit GitHub Action

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -1,0 +1,18 @@
+---
+name: Bundler Audit
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Bundler Audit"
+        uses: thoughtbot/bundler-audit-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This enabled to trigger `bundler-audit` in a Github Action for the following activity types:
- PR is opened
- PR has a new commit
- Closed PR is opened again

About `bundler-audit`: https://github.com/rubysec/bundler-audit