### PR TITLE
Add `#distance` and `#angular_size` to `Sun`

### DIFF
--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -2,6 +2,9 @@
 
 module Astronoby
   class Sun
+    SEMI_MAJOR_AXIS_IN_METERS = 149_598_500_000
+    ANGULAR_DIAMETER = Angle.as_degrees(0.533128)
+
     # Source:
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
@@ -27,6 +30,16 @@ module Astronoby
       ecliptic_coordinates
         .to_equatorial(epoch: @epoch)
         .to_horizontal(time: time, latitude: latitude, longitude: longitude)
+    end
+
+    # @return [Numeric] Earth-Sun distance in meters
+    def earth_distance
+      SEMI_MAJOR_AXIS_IN_METERS / distance_angular_size_factor
+    end
+
+    # @return [Angle] Apparent Sun's angular size
+    def angular_size
+      Angle.as_degrees(ANGULAR_DIAMETER.degrees * distance_angular_size_factor)
     end
 
     private
@@ -76,6 +89,13 @@ module Astronoby
       Angle.as_degrees(
         (0.01675104 - 0.0000418 * centuries - 0.000000126 * centuries**2) % 360
       )
+    end
+
+    def distance_angular_size_factor
+      term1 = 1 + orbital_eccentricity.degrees * true_anomaly.cos
+      term2 = 1 - orbital_eccentricity.degrees**2
+
+      term1 / term2
     end
   end
 end

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -182,4 +182,126 @@ RSpec.describe Astronoby::Sun do
       )
     end
   end
+
+  describe "#earth_distance" do
+    it "returns a number in meters" do
+      epoch = Astronoby::Epoch::DEFAULT_EPOCH
+      sun = described_class.new(epoch: epoch)
+
+      expect(sun.earth_distance).to be_a Numeric
+    end
+
+    # Source:
+    #  Title: Practical Astronomy with your Calculator or Spreadsheet
+    #  Authors: Peter Duffett-Smith and Jonathan Zwart
+    #  Edition: Cambridge University Press
+    #  Chapter: 48 - Calculating the Sun's distance and angular size
+    it "computes and return the Earth-Sun distance for a given epoch" do
+      time = Time.utc(1988, 7, 27)
+      epoch = Astronoby::Epoch.from_time(time)
+      sun = described_class.new(epoch: epoch)
+
+      expect(sun.earth_distance.round).to eq 151_920_130_151
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 6 - The Sun
+    it "computes and return the Earth-Sun distance for a given epoch" do
+      time = Time.utc(2015, 2, 15)
+      epoch = Astronoby::Epoch.from_time(time)
+      sun = described_class.new(epoch: epoch)
+
+      expect(sun.earth_distance.round).to eq 147_745_409_916
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 6 - The Sun
+    it "computes and return the Earth-Sun distance for a given epoch" do
+      time = Time.utc(2015, 8, 9)
+      epoch = Astronoby::Epoch.from_time(time)
+      sun = described_class.new(epoch: epoch)
+
+      expect(sun.earth_distance.round).to eq 151_683_526_945
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 6 - The Sun
+    it "computes and return the Earth-Sun distance for a given epoch" do
+      time = Time.utc(2010, 5, 6)
+      epoch = Astronoby::Epoch.from_time(time)
+      sun = described_class.new(epoch: epoch)
+
+      expect(sun.earth_distance.round).to eq 150_902_254_024
+    end
+  end
+
+  describe "#angular_size" do
+    it "returns an Angle" do
+      epoch = Astronoby::Epoch::DEFAULT_EPOCH
+      sun = described_class.new(epoch: epoch)
+
+      expect(sun.angular_size).to be_a Astronoby::Angle
+    end
+
+    # Source:
+    #  Title: Practical Astronomy with your Calculator or Spreadsheet
+    #  Authors: Peter Duffett-Smith and Jonathan Zwart
+    #  Edition: Cambridge University Press
+    #  Chapter: 48 - Calculating the Sun's distance and angular size
+    it "computes and return the Earth-Sun distance for a given epoch" do
+      time = Time.utc(1988, 7, 27)
+      epoch = Astronoby::Epoch.from_time(time)
+      sun = described_class.new(epoch: epoch)
+
+      expect(sun.angular_size.str(:dms)).to eq "+0° 31′ 29.9308″"
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 6 - The Sun
+    it "computes and return the Earth-Sun distance for a given epoch" do
+      time = Time.utc(2015, 2, 15)
+      epoch = Astronoby::Epoch.from_time(time)
+      sun = described_class.new(epoch: epoch)
+
+      expect(sun.angular_size.str(:dms)).to eq "+0° 32′ 23.333″"
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 6 - The Sun
+    it "computes and return the Earth-Sun distance for a given epoch" do
+      time = Time.utc(2015, 8, 9)
+      epoch = Astronoby::Epoch.from_time(time)
+      sun = described_class.new(epoch: epoch)
+
+      expect(sun.angular_size.str(:dms)).to eq "+0° 31′ 32.8788″"
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 6 - The Sun
+    it "computes and return the Earth-Sun distance for a given epoch" do
+      time = Time.utc(2010, 5, 6)
+      epoch = Astronoby::Epoch.from_time(time)
+      sun = described_class.new(epoch: epoch)
+
+      expect(sun.angular_size.str(:dms)).to eq "+0° 31′ 42.6789″"
+    end
+  end
 end


### PR DESCRIPTION
With the Sun's true anomaly available, it is convenient to compute the Earth-Sun distance and the Sun's apparent angular size.

The distance is of course an approximation. It is returned in meters as it is a SI unit, but it must not be seen as a value precise by the meter. For example, it doesn't count the observer's elevation or height.

Note that in the tests added, the precision for these two values taken from books examples weren't as high as in the tests. Therefore, the reader won't find matching results from the books. Also, these values will likely be updated as the precision of the library increases, which is acceptable as they weren't that close to the book examples in the first place.

```rb
time = Time.utc(2010, 5, 6)
epoch = Astronoby::Epoch.from_time(time)
sun = described_class.new(epoch: epoch)

sun.earth_distance.round
# => 150902254024

sun.angular_size.str(:dms)
# => "+0° 31′ 42.6789″"
```