### PR TITLE
Provide sunrise and sunset times

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -56,6 +56,14 @@ Returns the apparent Sun's true anomaly (`Angle`).
 
 Returns the apparent Sun's longitude (`Angle`) at its perigee.
 
+### `Sun#rising_time` method added (#35)
+
+Returns the UTC `Time` of the sunrise.
+
+### `Sun#setting_time` method added (#35)
+
+Returns the UTC `Time` of the sunset.
+
 ### Added comparison methods to `Angle` (#21)
 
 With the inclusion of `Comparable`, comparison methods such as `#==`, `#<`,

--- a/lib/astronoby/body.rb
+++ b/lib/astronoby/body.rb
@@ -14,8 +14,14 @@ module Astronoby
     #  Authors: Peter Duffett-Smith and Jonathan Zwart
     #  Edition: Cambridge University Press
     #  Chapter: 33 - Rising and setting
-    def rising_time(latitude:, longitude:, date:, apparent: true)
-      ratio = ratio(latitude, apparent)
+    def rising_time(
+      latitude:,
+      longitude:,
+      date:,
+      apparent: true,
+      vertical_shift: nil
+    )
+      ratio = ratio(latitude, apparent, vertical_shift)
       return nil unless RISING_SETTING_HOUR_ANGLE_RATIO_RANGE.cover?(ratio)
 
       hour_angle = Angle.acos(ratio)
@@ -46,8 +52,14 @@ module Astronoby
     #  Authors: Peter Duffett-Smith and Jonathan Zwart
     #  Edition: Cambridge University Press
     #  Chapter: 33 - Rising and setting
-    def setting_time(latitude:, longitude:, date:, apparent: true)
-      ratio = ratio(latitude, apparent)
+    def setting_time(
+      latitude:,
+      longitude:,
+      date:,
+      apparent: true,
+      vertical_shift: nil
+    )
+      ratio = ratio(latitude, apparent, vertical_shift)
       return nil unless RISING_SETTING_HOUR_ANGLE_RATIO_RANGE.cover?(ratio)
 
       hour_angle = Angle.acos(ratio)
@@ -75,8 +87,14 @@ module Astronoby
 
     private
 
-    def ratio(latitude, apparent)
-      shift = apparent ? DEFAULT_REFRACTION_VERTICAL_SHIFT : Angle.zero
+    def ratio(latitude, apparent, vertical_shift)
+      shift = if vertical_shift
+        vertical_shift
+      elsif apparent
+        DEFAULT_REFRACTION_VERTICAL_SHIFT
+      else
+        Angle.zero
+      end
 
       -(shift.sin + latitude.sin * @equatorial_coordinates.declination.sin)./(
         latitude.cos * @equatorial_coordinates.declination.cos

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -304,4 +304,150 @@ RSpec.describe Astronoby::Sun do
       expect(sun.angular_size.str(:dms)).to eq "+0° 31′ 42.6789″"
     end
   end
+
+  describe "#rising_time" do
+    it "returns a time" do
+      date = Date.new
+      epoch = Astronoby::Epoch.from_time(date)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.zero,
+        longitude: Astronoby::Angle.zero
+      )
+      sun = described_class.new(epoch: epoch)
+
+      setting_time = sun.rising_time(observer: observer)
+
+      expect(setting_time).to be_a(Time)
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 6 - The Sun
+    it "returns the Sun's rising time on 2015-02-05" do
+      date = Date.new(2015, 2, 5)
+      epoch = Astronoby::Epoch.from_time(date)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.as_degrees(38),
+        longitude: Astronoby::Angle.as_degrees(-78)
+      )
+      sun = described_class.new(epoch: epoch)
+
+      rising_time = sun.rising_time(observer: observer)
+
+      expect(rising_time).to eq Time.utc(2015, 2, 5, 12, 13, 27)
+      # Time from Celestial Calculations: 2015-02-05T12:18:00
+      # Time from IMCCE: 2015-02-05T12:14:12
+    end
+
+    # Source:
+    #  Title: Practical Astronomy with your Calculator or Spreadsheet
+    #  Authors: Peter Duffett-Smith and Jonathan Zwart
+    #  Edition: Cambridge University Press
+    #  Chapter: 49 - Sunrise and sunset
+    it "returns the Sun's rising time on 1986-03-10" do
+      date = Date.new(1986, 3, 10)
+      epoch = Astronoby::Epoch.from_time(date)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.as_degrees(42.37),
+        longitude: Astronoby::Angle.as_degrees(-71.05)
+      )
+      sun = described_class.new(epoch: epoch)
+
+      rising_time = sun.rising_time(observer: observer)
+
+      expect(rising_time).to eq Time.utc(1986, 3, 10, 11, 5, 43)
+      # Time from Practical Astronomy: 1986-03-10T11:06:00
+      # Time from IMCCE: 1986-03-10T11:06:22
+    end
+
+    it "returns the Sun's rising time on 1991-03-14" do
+      date = Date.new(1991, 3, 14)
+      epoch = Astronoby::Epoch.from_time(date)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.as_degrees(48.8566),
+        longitude: Astronoby::Angle.as_degrees(2.3522)
+      )
+      sun = described_class.new(epoch: epoch)
+
+      rising_time = sun.rising_time(observer: observer)
+
+      expect(rising_time).to eq Time.utc(1991, 3, 14, 6, 8, 16)
+      # Time from IMCCE: 1991-03-14T06:08:45
+    end
+  end
+
+  describe "#setting_time" do
+    it "returns a time" do
+      date = Date.new
+      epoch = Astronoby::Epoch.from_time(date)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.zero,
+        longitude: Astronoby::Angle.zero
+      )
+      sun = described_class.new(epoch: epoch)
+
+      setting_time = sun.setting_time(observer: observer)
+
+      expect(setting_time).to be_a(Time)
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 6 - The Sun
+    it "returns the Sun's setting time on 2015-02-05" do
+      date = Date.new(2015, 2, 5)
+      epoch = Astronoby::Epoch.from_time(date)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.as_degrees(38),
+        longitude: Astronoby::Angle.as_degrees(-78)
+      )
+      sun = described_class.new(epoch: epoch)
+
+      setting_time = sun.setting_time(observer: observer)
+
+      expect(setting_time).to eq Time.utc(2015, 2, 5, 22, 35, 14)
+      # Time from Celestial Calculations: 2015-02-05T22:31:00
+      # Time from IMCCE: 2015-02-05T22:49:16
+    end
+
+    # Source:
+    #  Title: Practical Astronomy with your Calculator or Spreadsheet
+    #  Authors: Peter Duffett-Smith and Jonathan Zwart
+    #  Edition: Cambridge University Press
+    #  Chapter: 49 - Sunrise and sunset
+    it "returns the Sun's setting time on 1986-03-10" do
+      date = Date.new(1986, 3, 10)
+      epoch = Astronoby::Epoch.from_time(date)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.as_degrees(42.37),
+        longitude: Astronoby::Angle.as_degrees(-71.05)
+      )
+      sun = described_class.new(epoch: epoch)
+
+      setting_time = sun.setting_time(observer: observer)
+
+      expect(setting_time).to eq Time.utc(1986, 3, 10, 22, 40, 55)
+      # Time from Practical Astronomy: 1986-03-10T22:43:00
+      # Time from IMCCE: 1986-03-10T22:43:22
+    end
+
+    it "returns the Sun's setting time on 1991-03-14" do
+      date = Date.new(1991, 3, 14)
+      epoch = Astronoby::Epoch.from_time(date)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.as_degrees(48.8566),
+        longitude: Astronoby::Angle.as_degrees(2.3522)
+      )
+      sun = described_class.new(epoch: epoch)
+
+      setting_time = sun.setting_time(observer: observer)
+
+      expect(setting_time).to eq Time.utc(1991, 3, 14, 17, 50, 37)
+      # Time from IMCCE: 1991-03-14T17:52:00
+    end
+  end
 end


### PR DESCRIPTION
This implements `#rising_time` and `#setting_time` on `Astronoby::Sun`. As they are named, they return times (`Time`) of sunrise and sunset in UTC.

From my tests, the closest I can get from times computes by the IMCCE are within 30 seconds to 2 minutes of precision.

```rb
date = Date.new(1991, 3, 14)
epoch = Astronoby::Epoch.from_time(date)
observer = Astronoby::Observer.new(
  latitude: Astronoby::Angle.as_degrees(48.8566),
  longitude: Astronoby::Angle.as_degrees(2.3522)
)
sun = Astronoby::Sun.new(epoch: epoch)

sun.rising_time(observer: observer)
# => 1991-03-14 06:08:16 UTC

sun.setting_time(observer: observer)
# => 1991-03-14 17:50:37 UTC
```