### PR TITLE
Round rising and setting times to the second

### DIFF
--- a/lib/astronoby/time/greenwich_sidereal_time.rb
+++ b/lib/astronoby/time/greenwich_sidereal_time.rb
@@ -80,7 +80,7 @@ module Astronoby
       minute = decimal_minute.floor
       second = 60 * (absolute_decimal_minute - absolute_decimal_minute.floor)
 
-      ::Time.utc(date.year, date.month, date.day, hour, minute, second)
+      ::Time.utc(date.year, date.month, date.day, hour, minute, second).round
     end
   end
 end

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -336,7 +336,7 @@ RSpec.describe Astronoby::Sun do
 
       rising_time = sun.rising_time(observer: observer)
 
-      expect(rising_time.round).to eq Time.utc(2015, 2, 5, 12, 13, 27)
+      expect(rising_time).to eq Time.utc(2015, 2, 5, 12, 13, 27)
       # Time from Celestial Calculations: 2015-02-05T12:18:00
       # Time from IMCCE: 2015-02-05T12:14:12
     end
@@ -357,7 +357,7 @@ RSpec.describe Astronoby::Sun do
 
       rising_time = sun.rising_time(observer: observer)
 
-      expect(rising_time.round).to eq Time.utc(1986, 3, 10, 11, 5, 43)
+      expect(rising_time).to eq Time.utc(1986, 3, 10, 11, 5, 43)
       # Time from Practical Astronomy: 1986-03-10T11:06:00
       # Time from IMCCE: 1986-03-10T11:06:22
     end
@@ -373,7 +373,7 @@ RSpec.describe Astronoby::Sun do
 
       rising_time = sun.rising_time(observer: observer)
 
-      expect(rising_time.round).to eq Time.utc(1991, 3, 14, 6, 8, 16)
+      expect(rising_time).to eq Time.utc(1991, 3, 14, 6, 8, 16)
       # Time from IMCCE: 1991-03-14T06:08:45
     end
   end
@@ -409,7 +409,7 @@ RSpec.describe Astronoby::Sun do
 
       setting_time = sun.setting_time(observer: observer)
 
-      expect(setting_time.round).to eq Time.utc(2015, 2, 5, 22, 35, 13)
+      expect(setting_time).to eq Time.utc(2015, 2, 5, 22, 35, 14)
       # Time from Celestial Calculations: 2015-02-05T22:31:00
       # Time from IMCCE: 2015-02-05T22:49:16
     end
@@ -430,7 +430,7 @@ RSpec.describe Astronoby::Sun do
 
       setting_time = sun.setting_time(observer: observer)
 
-      expect(setting_time.round).to eq Time.utc(1986, 3, 10, 22, 40, 55)
+      expect(setting_time).to eq Time.utc(1986, 3, 10, 22, 40, 55)
       # Time from Practical Astronomy: 1986-03-10T22:43:00
       # Time from IMCCE: 1986-03-10T22:43:22
     end
@@ -446,7 +446,7 @@ RSpec.describe Astronoby::Sun do
 
       setting_time = sun.setting_time(observer: observer)
 
-      expect(setting_time.round).to eq Time.utc(1991, 3, 14, 17, 50, 37)
+      expect(setting_time).to eq Time.utc(1991, 3, 14, 17, 50, 37)
       # Time from IMCCE: 1991-03-14T17:52:00
     end
   end

--- a/spec/astronoby/body_spec.rb
+++ b/spec/astronoby/body_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Astronoby::Body do
         apparent: false
       )
 
-      expect(rising_time&.round).to eq(Time.utc(2016, 1, 21, 20, 40, 46))
+      expect(rising_time).to eq(Time.utc(2016, 1, 21, 20, 40, 46))
     end
 
     # Source:
@@ -71,7 +71,7 @@ RSpec.describe Astronoby::Body do
         apparent: false
       )
 
-      expect(rising_time&.getlocal(offset)&.round)
+      expect(rising_time&.getlocal(offset))
         .to eq(Time.new(2015, 6, 6, 16, 57, 48, offset))
     end
 
@@ -93,7 +93,7 @@ RSpec.describe Astronoby::Body do
         date: Date.new(2010, 8, 24)
       )
 
-      expect(rising_time&.round).to eq(Time.utc(2010, 8, 24, 14, 16, 18))
+      expect(rising_time).to eq(Time.utc(2010, 8, 24, 14, 16, 18))
     end
   end
 
@@ -142,7 +142,7 @@ RSpec.describe Astronoby::Body do
         apparent: false
       )
 
-      expect(setting_time&.round).to eq(Time.utc(2016, 1, 21, 9, 29, 50))
+      expect(setting_time).to eq(Time.utc(2016, 1, 21, 9, 29, 50))
     end
 
     # Source:
@@ -189,7 +189,7 @@ RSpec.describe Astronoby::Body do
         apparent: false
       )
 
-      expect(setting_time&.round).to eq(Time.utc(2015, 6, 6, 11, 59, 51))
+      expect(setting_time).to eq(Time.utc(2015, 6, 6, 11, 59, 51))
     end
 
     # Source:
@@ -210,7 +210,7 @@ RSpec.describe Astronoby::Body do
         date: Date.new(2010, 8, 24)
       )
 
-      expect(setting_time&.round).to eq(Time.utc(2010, 8, 24, 4, 10, 1))
+      expect(setting_time).to eq(Time.utc(2010, 8, 24, 4, 10, 1))
     end
   end
 

--- a/spec/astronoby/time/greenwich_sidereal_time_spec.rb
+++ b/spec/astronoby/time/greenwich_sidereal_time_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Astronoby::GreenwichSiderealTime do
 
       utc = gst.to_utc
 
-      expect(utc.round(2)).to eq Time.utc(1980, 4, 22, 14, 36, 51.67).round(2)
+      expect(utc).to eq Time.utc(1980, 4, 22, 14, 36, 52)
     end
   end
 end


### PR DESCRIPTION
It is very unlikely that we will reach a level of precision for rising and setting times below the second.

In the mean time, all the digits remaining from using BigDecimal in time calculation make it hard to read.

This rounds rising and setting times to the second.