### PR TITLE
Compute the equation of time

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,10 @@ default vertical refraction angle or not.
 With a default value of `true`, this new argument will make consider a
 default vertical refraction angle or not.
 
+### `Sun::equation_of_time` method added (#40)
+
+Returns the equation of time for a given date.
+
 ### `Sun#distance` method added (#30)
 
 Returns the approximate Earth-Sun distance in meters (`Numeric`).

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -7,6 +7,30 @@ module Astronoby
     INTERPOLATION_FACTOR = BigDecimal("24.07")
 
     # Source:
+    #  Title: Practical Astronomy with your Calculator or Spreadsheet
+    #  Authors: Peter Duffett-Smith and Jonathan Zwart
+    #  Edition: Cambridge University Press
+    #  Chapter: 51 - The equation of time
+
+    # @param date [Date] Requested date
+    # @return [Integer] Equation of time in seconds
+    def self.equation_of_time(date:)
+      noon = Time.utc(date.year, date.month, date.day, 12)
+      epoch_at_noon = Epoch.from_time(noon)
+      sun_at_noon = new(epoch: epoch_at_noon)
+      equatorial_hours = sun_at_noon
+        .ecliptic_coordinates
+        .to_equatorial(epoch: epoch_at_noon)
+        .right_ascension
+        .hours
+      gst = GreenwichSiderealTime
+        .new(date: date, time: equatorial_hours)
+        .to_utc
+
+      (noon - gst).to_i
+    end
+
+    # Source:
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -572,4 +572,84 @@ RSpec.describe Astronoby::Sun do
       # Time from IMCCE: +266° 52′
     end
   end
+
+  describe "::equation_of_time" do
+    it "returns an Integer" do
+      date = Date.new
+
+      equation_of_time = described_class.equation_of_time(date: date)
+
+      expect(equation_of_time).to be_an Integer
+    end
+
+    # Source:
+    #  Title: Practical Astronomy with your Calculator or Spreadsheet
+    #  Authors: Peter Duffett-Smith and Jonathan Zwart
+    #  Edition: Cambridge University Press
+    #  Chapter: 51 - The equation of time
+    it "returns the right value of 2010-07-27" do
+      date = Date.new(2010, 7, 27)
+
+      equation_of_time = described_class.equation_of_time(date: date)
+
+      expect(equation_of_time).to eq(-392)
+      # Value from Practical Astronomy: 392
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 6 - The Sun
+    it "returns the right value of 2016-05-05" do
+      date = Date.new(2016, 5, 5)
+
+      equation_of_time = described_class.equation_of_time(date: date)
+
+      expect(equation_of_time).to eq(199)
+      # Value from Celestial Calculations: 199
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 6 - The Sun
+    it "returns the right value of 2015-08-09" do
+      date = Date.new(2015, 8, 9)
+
+      equation_of_time = described_class.equation_of_time(date: date)
+
+      expect(equation_of_time).to eq(-334)
+      # Value from Celestial Calculations: 337
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 6 - The Sun
+    it "returns the right value of 2010-05-06" do
+      date = Date.new(2010, 5, 6)
+
+      equation_of_time = described_class.equation_of_time(date: date)
+
+      expect(equation_of_time).to eq(201)
+      # Value from Celestial Calculations: 201
+    end
+
+    # Source:
+    #  Title: Celestial Calculations
+    #  Author: J. L. Lawrence
+    #  Edition: MIT Press
+    #  Chapter: 6 - The Sun
+    it "returns the right value of 2020-01-01" do
+      date = Date.new(2020, 1, 1)
+
+      equation_of_time = described_class.equation_of_time(date: date)
+
+      expect(equation_of_time).to eq(-200)
+      # Value from Celestial Calculations: 187
+    end
+  end
 end


### PR DESCRIPTION
The equation of time is the difference of the real Sun time and the mean Sun time. This difference is due to the elliptical shape of the Earth's orbit, and the obliquity of the orbit.

`Sun` now has a `#equation_of_time` method that returns an integer: the time difference in seconds.

```rb
date = Date.new(2010, 7, 27)

Astronoby::Sun.equation_of_time(date: date)
# => -392
```