### PR TITLE
Difference between true and apparent ecliptic and equatorial coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,45 @@ This library is still in heavy development. The public is not stable, please
 be aware new minor versions will probably lead to breaking changes until a
 major one is released.
 
+### Angle manipulation
+
+```rb
+angle1 = Astronoby::Angle.as_degrees(90)
+angle2 = Astronoby::Angle.as_radians(Astronoby::Angle::PI / 2)
+angle3 = Astronoby::Angle.as_hours(12)
+
+angle1 == angle2
+# => true
+
+angle1 < angle3
+# => true
+
+angle = angle1 + angle2 + angle3
+angle.cos
+# => 1.0
+```
+
+### Coordinates conversion
+
+```rb
+equatorial = Astronoby::Coordinates::Equatorial.new(
+  right_ascension: Astronoby::Angle.as_hms(17, 43, 54),
+  declination: Astronoby::Angle.as_dms(-22, 10, 0)
+)
+
+horizontal = equatorial.to_horizontal(
+  time: Time.new(2016, 1, 21, 21, 30, 0, "-05:00"),
+  latitude: Astronoby::Angle.as_degrees(38),
+  longitude: Astronoby::Angle.as_degrees(-78)
+)
+
+horizontal.altitude.str(:dms)
+# => "-73° 27′ 19.1557″"
+
+horizontal.azimuth.str(:dms)
+# => "+341° 33′ 21.587″"
+```
+
 ### Sun's location in the sky
 
 ```rb
@@ -45,10 +84,34 @@ horizontal_coordinates = sun.horizontal_coordinates(
 )
 
 horizontal_coordinates.altitude.degrees.to_f
-# => 27.502365130176567
+# => 27.50008242057459
 
 horizontal_coordinates.altitude.str(:dms)
-# => "+27° 30′ 8.5144″"
+# => "+27° 30′ 0.2967″"
+```
+
+### Sunrise and sunset times and azimuths
+
+```rb
+date = Date.new(2015, 2, 5)
+epoch = Astronoby::Epoch.from_time(date)
+observer = Astronoby::Observer.new(
+  latitude: Astronoby::Angle.as_degrees(38),
+  longitude: Astronoby::Angle.as_degrees(-78)
+)
+sun = Astronoby::Sun.new(epoch: epoch)
+
+sun.rising_time(observer: observer)
+# => 2015-02-05 12:13:26 UTC
+
+sun.rising_azimuth(observer: observer).str(:dms)
+# => "+109° 41′ 22.2585″"
+
+sun.setting_time(observer: observer)
+# => 2015-02-05 22:35:12 UTC
+
+sun.setting_azimuth(observer: observer).str(:dms)
+# => "+250° 18′ 37.7414″"
 ```
 
 ### Solstice and Equinox times
@@ -57,10 +120,10 @@ horizontal_coordinates.altitude.str(:dms)
 year = 2024
 
 Astronoby::EquinoxSolstice.march_equinox(year)
-# => 2024-03-20 03:05:00 UTC
+# => 2024-03-20 03:05:08 UTC
 
 Astronoby::EquinoxSolstice.june_solstice(year)
-# => 2024-06-20 20:50:14 UTC
+# => 2024-06-20 20:50:18 UTC
 ```
 
 ## Precision

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,6 +7,36 @@ changes to it as long as a major version has not been released.
 If you are already using Astronoby and wish to follow the changes to its
 public API, please read the upgrading notes for each release.
 
+## Upgrading from 0.2.0 to 0.3.0
+
+### `Sun#ecliptic_coordinates` method removed (#41)
+
+Removed in favor of `#true_ecliptic_coordinates` and
+`#apparent_ecliptic_coordinates`.
+
+### `Coordinates::Ecliptic#to_horizontal` method removed (#41)
+
+Removed in favor of `#to_true_horizontal` and
+`#to_apparent_horizontal`.
+
+### `Sun#true_ecliptic_coordinates` method added (#41)
+
+Returns the true ecliptic coordinates for the date's epoch.
+
+### `Sun#apparent_ecliptic_coordinates` method added (#41)
+
+Returns the apparent ecliptic coordinates for the date's epoch, including
+corrections for the nutation and aberration.
+
+### `Coordinates::Ecliptic#to_true_horizontal` method added (#41)
+
+Returns the true equatorial coordinates for ths date's epoch.
+
+### `Coordinates::Ecliptic#to_apparent_horizontal` method added (#41)
+
+Returns the apparent equatorial coordinates for the date's epoch, including
+corrections for the obliquity.
+
 ## Upgrading from 0.1.0 to 0.2.0
 
 ### `Observer` class added (#29)

--- a/lib/astronoby/aberration.rb
+++ b/lib/astronoby/aberration.rb
@@ -36,7 +36,10 @@ module Astronoby
     end
 
     def sun_longitude
-      @_sun_longitude ||= Sun.new(epoch: @epoch).ecliptic_coordinates.longitude
+      @_sun_longitude ||= Sun
+        .new(epoch: @epoch)
+        .true_ecliptic_coordinates
+        .longitude
     end
   end
 end

--- a/lib/astronoby/coordinates/ecliptic.rb
+++ b/lib/astronoby/coordinates/ecliptic.rb
@@ -15,26 +15,37 @@ module Astronoby
       #  Author: J. L. Lawrence
       #  Edition: MIT Press
       #  Chapter: 4 - Orbits and Coordinate Systems
-      def to_equatorial(epoch:)
-        mean_obliquity = MeanObliquity.for_epoch(epoch)
 
+      def to_true_equatorial(epoch:)
+        mean_obliquity = MeanObliquity.for_epoch(epoch)
+        to_equatorial(obliquity: mean_obliquity)
+      end
+
+      def to_apparent_equatorial(epoch:)
+        apparent_obliquity = TrueObliquity.for_epoch(epoch)
+        to_equatorial(obliquity: apparent_obliquity)
+      end
+
+      private
+
+      def to_equatorial(obliquity:)
         y = Angle.as_radians(
-          @longitude.sin * mean_obliquity.cos -
-          @latitude.tan * mean_obliquity.sin
+          @longitude.sin * obliquity.cos -
+            @latitude.tan * obliquity.sin
         )
         x = Angle.as_radians(@longitude.cos)
         r = Angle.atan(y.radians / x.radians)
         right_ascension = Util::Trigonometry.adjustement_for_arctangent(y, x, r)
 
         declination = Angle.asin(
-          @latitude.sin * mean_obliquity.cos +
-          @latitude.cos * mean_obliquity.sin * @longitude.sin
+          @latitude.sin * obliquity.cos +
+            @latitude.cos * obliquity.sin * @longitude.sin
         )
 
         Equatorial.new(
           right_ascension: right_ascension,
           declination: declination,
-          epoch: epoch
+          epoch: @epoch
         )
       end
     end

--- a/lib/astronoby/equinox_solstice.rb
+++ b/lib/astronoby/equinox_solstice.rb
@@ -131,23 +131,9 @@ module Astronoby
 
     def correction(epoch)
       sun = Sun.new(epoch: epoch)
+      longitude = sun.apparent_ecliptic_coordinates.longitude
 
-      nutation = Nutation.for_ecliptic_longitude(epoch: epoch)
-
-      earth_radius_vector = 1 / (
-        1 +
-          sun.orbital_eccentricity.degrees *
-            (sun.true_anomaly - sun.longitude_at_perigee).cos
-      )
-      aberration = Angle.as_degrees(
-        Angle.as_dms(0, 0, 20.4898).degrees / -earth_radius_vector
-      )
-
-      corrected_longitude = sun.ecliptic_coordinates.longitude +
-        nutation +
-        aberration
-
-      58 * Angle.as_degrees(@event * 90 - corrected_longitude.degrees).sin
+      58 * Angle.as_degrees(@event * 90 - longitude.degrees).sin
     end
   end
 end

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Astronoby::Sun do
-  describe "#ecliptic_coordinates" do
+  describe "#true_ecliptic_coordinates" do
     it "returns ecliptic coordinates" do
       epoch = Astronoby::Epoch::DEFAULT_EPOCH
 
-      coordinates = described_class.new(epoch: epoch).ecliptic_coordinates
+      coordinates = described_class.new(epoch: epoch).true_ecliptic_coordinates
 
       expect(coordinates).to be_a(Astronoby::Coordinates::Ecliptic)
     end
@@ -14,87 +14,82 @@ RSpec.describe Astronoby::Sun do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
-    it "computes the coordinates for a given epoch" do
+    #  Chapter: 6 - The Sun, p136
+    it "computes the coordinates for 2015-02-05" do
       time = Time.new(2015, 2, 5, 12, 0, 0, "-05:00")
       epoch = Astronoby::Epoch.from_time(time)
 
-      ecliptic_coordinates = described_class.new(epoch: epoch).ecliptic_coordinates
+      ecliptic_coordinates = described_class
+        .new(epoch: epoch)
+        .true_ecliptic_coordinates
 
       expect(ecliptic_coordinates.longitude.degrees.to_f).to(
         eq(316.5726713406949)
       )
+      # Result from the book: 316.562255
     end
 
     # Source:
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
-    it "computes the coordinates for a given epoch" do
+    #  Chapter: 6 - The Sun, p149
+    #
+    it "computes the coordinates for 2000-08-09" do
       time = Time.new(2000, 8, 9, 12, 0, 0, "-04:00")
       epoch = Astronoby::Epoch.from_time(time)
 
-      ecliptic_coordinates = described_class.new(epoch: epoch).ecliptic_coordinates
+      ecliptic_coordinates = described_class
+        .new(epoch: epoch)
+        .true_ecliptic_coordinates
 
       expect(ecliptic_coordinates.longitude.degrees.to_f).to(
         eq(137.36484079770798)
       )
+      # Result from the book: 137.386004
     end
 
     # Source:
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
-    it "computes the coordinates for a given epoch" do
+    #  Chapter: 6 - The Sun, p149
+    it "computes the coordinates for 2015-05-06" do
       time = Time.new(2015, 5, 6, 14, 30, 0, "-04:00")
       epoch = Astronoby::Epoch.from_time(time)
 
-      ecliptic_coordinates = described_class.new(epoch: epoch).ecliptic_coordinates
+      ecliptic_coordinates = described_class
+        .new(epoch: epoch)
+        .true_ecliptic_coordinates
 
       expect(ecliptic_coordinates.longitude.degrees.to_f).to(
         eq(45.92185191445673)
       )
+      # Result from the book: 45.917857
     end
 
     # Source:
     #  Title: Practical Astronomy with your Calculator or Spreadsheet
     #  Authors: Peter Duffett-Smith and Jonathan Zwart
     #  Edition: Cambridge University Press
-    #  Chapter: 47 - Calculating orbits more precisely
-    it "computes the coordinates for a given epoch" do
+    #  Chapter: 47 - Calculating orbits more precisely, p109
+    it "computes the coordinates for 1988-07-27" do
       time = Time.utc(1988, 7, 27, 0, 0, 0)
       epoch = Astronoby::Epoch.from_time(time)
 
-      ecliptic_coordinates = described_class.new(epoch: epoch).ecliptic_coordinates
-      equatorial_coordinates = ecliptic_coordinates.to_equatorial(epoch: epoch)
+      ecliptic_coordinates = described_class
+        .new(epoch: epoch)
+        .true_ecliptic_coordinates
+      equatorial_coordinates = ecliptic_coordinates
+        .to_true_equatorial(epoch: epoch)
 
       expect(equatorial_coordinates.right_ascension.str(:hms)).to(
         eq("8h 26m 3.6131s")
+        # Result from the book: 8h 26m 4s
       )
       expect(equatorial_coordinates.declination.str(:dms)).to(
         eq("+19° 12′ 43.1836″")
-      )
-    end
-
-    # Source:
-    #  Title: Astronomical Algorithms
-    #  Author: Jean Meeus
-    #  Edition: 2nd edition
-    #  Chapter: 22 - Nutation and the Obliquity of the Ecliptic
-    it "computes the coordinates for a given epoch" do
-      time = Time.utc(1992, 10, 13, 0, 0, 0)
-      epoch = Astronoby::Epoch.from_time(time)
-
-      ecliptic_coordinates = described_class.new(epoch: epoch).ecliptic_coordinates
-      equatorial_coordinates = ecliptic_coordinates.to_equatorial(epoch: epoch)
-
-      expect(equatorial_coordinates.right_ascension.str(:hms)).to(
-        eq("13h 13m 31.4636s")
-      )
-      expect(equatorial_coordinates.declination.str(:dms)).to(
-        eq("-7° 47′ 6.9653″")
+        # Result from the book: 19° 12′ 43″
       )
     end
   end
@@ -117,7 +112,7 @@ RSpec.describe Astronoby::Sun do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.137
     it "computes the horizontal coordinates for the epoch" do
       time = Time.new(2015, 2, 5, 12, 0, 0, "-05:00")
       epoch = Astronoby::Epoch.from_time(time)
@@ -129,10 +124,12 @@ RSpec.describe Astronoby::Sun do
       )
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
-        eq("+35° 47′ 12.6437″")
+        eq("+35° 47′ 15.717″")
+        # Result from the book: 35° 47′ 0.1″
       )
       expect(horizontal_coordinates.azimuth.str(:dms)).to(
-        eq("+172° 17′ 2.7301″")
+        eq("+172° 17′ 22.7259″")
+        # Result from the book: 172° 17′ 46″
       )
     end
 
@@ -140,7 +137,7 @@ RSpec.describe Astronoby::Sun do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.149
     it "computes the coordinates for a given epoch" do
       time = Time.new(2000, 8, 9, 12, 0, 0, "-05:00")
       epoch = Astronoby::Epoch.from_time(time)
@@ -152,10 +149,12 @@ RSpec.describe Astronoby::Sun do
       )
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
-        eq("+65° 41′ 50.1342″")
+        eq("+65° 42′ 21.6059″")
+        # Result from the book: 65° 43′
       )
       expect(horizontal_coordinates.azimuth.str(:dms)).to(
-        eq("+121° 32′ 44.7251″")
+        eq("+121° 33′ 22.4259″")
+        # Result from the book: 121° 34′
       )
     end
 
@@ -163,7 +162,7 @@ RSpec.describe Astronoby::Sun do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.149
     it "computes the coordinates for a given epoch" do
       time = Time.new(2015, 5, 6, 14, 30, 0, "-04:00")
       epoch = Astronoby::Epoch.from_time(time)
@@ -175,10 +174,12 @@ RSpec.describe Astronoby::Sun do
       )
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
-        eq("+13° 34′ 17.4237″")
+        eq("+13° 34′ 7.6911″")
+        # Result from the book: 13° 34′
       )
       expect(horizontal_coordinates.azimuth.str(:dms)).to(
-        eq("+293° 37′ 12.5231″")
+        eq("+293° 36′ 54.0812″")
+        # Result from the book: 293° 37′
       )
     end
   end
@@ -195,52 +196,56 @@ RSpec.describe Astronoby::Sun do
     #  Title: Practical Astronomy with your Calculator or Spreadsheet
     #  Authors: Peter Duffett-Smith and Jonathan Zwart
     #  Edition: Cambridge University Press
-    #  Chapter: 48 - Calculating the Sun's distance and angular size
+    #  Chapter: 48 - Calculating the Sun's distance and angular size, p.110
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(1988, 7, 27)
       epoch = Astronoby::Epoch.from_time(time)
       sun = described_class.new(epoch: epoch)
 
       expect(sun.earth_distance.round).to eq 151_920_130_151
+      # Result from the book: 1.519189×10^8 km
     end
 
     # Source:
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.147
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(2015, 2, 15)
       epoch = Astronoby::Epoch.from_time(time)
       sun = described_class.new(epoch: epoch)
 
       expect(sun.earth_distance.round).to eq 147_745_409_916
+      # Result from the book: 1.478×10^8 km
     end
 
     # Source:
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.150
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(2015, 8, 9)
       epoch = Astronoby::Epoch.from_time(time)
       sun = described_class.new(epoch: epoch)
 
       expect(sun.earth_distance.round).to eq 151_683_526_945
+      # Result from the book: 1.517×10^8 km
     end
 
     # Source:
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.150
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(2010, 5, 6)
       epoch = Astronoby::Epoch.from_time(time)
       sun = described_class.new(epoch: epoch)
 
       expect(sun.earth_distance.round).to eq 150_902_254_024
+      # Result from the book: 1.509×10^8 km
     end
   end
 
@@ -256,52 +261,56 @@ RSpec.describe Astronoby::Sun do
     #  Title: Practical Astronomy with your Calculator or Spreadsheet
     #  Authors: Peter Duffett-Smith and Jonathan Zwart
     #  Edition: Cambridge University Press
-    #  Chapter: 48 - Calculating the Sun's distance and angular size
+    #  Chapter: 48 - Calculating the Sun's distance and angular size, p.110
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(1988, 7, 27)
       epoch = Astronoby::Epoch.from_time(time)
       sun = described_class.new(epoch: epoch)
 
       expect(sun.angular_size.str(:dms)).to eq "+0° 31′ 29.9308″"
+      # Result from the book: 0° 31′ 30″
     end
 
     # Source:
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.147
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(2015, 2, 15)
       epoch = Astronoby::Epoch.from_time(time)
       sun = described_class.new(epoch: epoch)
 
       expect(sun.angular_size.str(:dms)).to eq "+0° 32′ 23.333″"
+      # Result from the book: 0° 32′″
     end
 
     # Source:
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.150
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(2015, 8, 9)
       epoch = Astronoby::Epoch.from_time(time)
       sun = described_class.new(epoch: epoch)
 
       expect(sun.angular_size.str(:dms)).to eq "+0° 31′ 32.8788″"
+      # Result from the book: 0° 32′″
     end
 
     # Source:
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.150
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(2010, 5, 6)
       epoch = Astronoby::Epoch.from_time(time)
       sun = described_class.new(epoch: epoch)
 
       expect(sun.angular_size.str(:dms)).to eq "+0° 31′ 42.6789″"
+      # Result from the book: 0° 32′″
     end
   end
 
@@ -324,7 +333,7 @@ RSpec.describe Astronoby::Sun do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.139
     it "returns the Sun's rising time on 2015-02-05" do
       date = Date.new(2015, 2, 5)
       epoch = Astronoby::Epoch.from_time(date)
@@ -336,7 +345,7 @@ RSpec.describe Astronoby::Sun do
 
       rising_time = sun.rising_time(observer: observer)
 
-      expect(rising_time).to eq Time.utc(2015, 2, 5, 12, 13, 27)
+      expect(rising_time).to eq Time.utc(2015, 2, 5, 12, 13, 26)
       # Time from Celestial Calculations: 2015-02-05T12:18:00
       # Time from IMCCE: 2015-02-05T12:14:12
     end
@@ -345,7 +354,7 @@ RSpec.describe Astronoby::Sun do
     #  Title: Practical Astronomy with your Calculator or Spreadsheet
     #  Authors: Peter Duffett-Smith and Jonathan Zwart
     #  Edition: Cambridge University Press
-    #  Chapter: 49 - Sunrise and sunset
+    #  Chapter: 49 - Sunrise and sunset, p.112
     it "returns the Sun's rising time on 1986-03-10" do
       date = Date.new(1986, 3, 10)
       epoch = Astronoby::Epoch.from_time(date)
@@ -357,7 +366,7 @@ RSpec.describe Astronoby::Sun do
 
       rising_time = sun.rising_time(observer: observer)
 
-      expect(rising_time).to eq Time.utc(1986, 3, 10, 11, 5, 43)
+      expect(rising_time).to eq Time.utc(1986, 3, 10, 11, 5, 42)
       # Time from Practical Astronomy: 1986-03-10T11:06:00
       # Time from IMCCE: 1986-03-10T11:06:22
     end
@@ -404,7 +413,7 @@ RSpec.describe Astronoby::Sun do
 
       rising_azimuth = sun.rising_azimuth(observer: observer)
 
-      expect(rising_azimuth&.str(:dms)).to eq "+109° 41′ 24.0917″"
+      expect(rising_azimuth&.str(:dms)).to eq "+109° 41′ 22.2585″"
       # Time from IMCCE: +109° 53′
     end
 
@@ -419,7 +428,7 @@ RSpec.describe Astronoby::Sun do
 
       rising_azimuth = sun.rising_azimuth(observer: observer)
 
-      expect(rising_azimuth&.str(:dms)).to eq "+94° 59′ 15.7852″"
+      expect(rising_azimuth&.str(:dms)).to eq "+94° 59′ 33.1791″"
       # Time from IMCCE: +95° 02′
     end
 
@@ -434,7 +443,7 @@ RSpec.describe Astronoby::Sun do
 
       rising_azimuth = sun.rising_azimuth(observer: observer)
 
-      expect(rising_azimuth&.str(:dms)).to eq "+93° 26′ 26.8564″"
+      expect(rising_azimuth&.str(:dms)).to eq "+93° 26′ 30.3551″"
       # Time from IMCCE: +93° 26′
     end
   end
@@ -458,7 +467,7 @@ RSpec.describe Astronoby::Sun do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.139
     it "returns the Sun's setting time on 2015-02-05" do
       date = Date.new(2015, 2, 5)
       epoch = Astronoby::Epoch.from_time(date)
@@ -470,7 +479,7 @@ RSpec.describe Astronoby::Sun do
 
       setting_time = sun.setting_time(observer: observer)
 
-      expect(setting_time).to eq Time.utc(2015, 2, 5, 22, 35, 14)
+      expect(setting_time).to eq Time.utc(2015, 2, 5, 22, 35, 12)
       # Time from Celestial Calculations: 2015-02-05T22:31:00
       # Time from IMCCE: 2015-02-05T22:49:16
     end
@@ -479,7 +488,7 @@ RSpec.describe Astronoby::Sun do
     #  Title: Practical Astronomy with your Calculator or Spreadsheet
     #  Authors: Peter Duffett-Smith and Jonathan Zwart
     #  Edition: Cambridge University Press
-    #  Chapter: 49 - Sunrise and sunset
+    #  Chapter: 49 - Sunrise and sunset, p.112
     it "returns the Sun's setting time on 1986-03-10" do
       date = Date.new(1986, 3, 10)
       epoch = Astronoby::Epoch.from_time(date)
@@ -491,7 +500,7 @@ RSpec.describe Astronoby::Sun do
 
       setting_time = sun.setting_time(observer: observer)
 
-      expect(setting_time).to eq Time.utc(1986, 3, 10, 22, 40, 55)
+      expect(setting_time).to eq Time.utc(1986, 3, 10, 22, 40, 52)
       # Time from Practical Astronomy: 1986-03-10T22:43:00
       # Time from IMCCE: 1986-03-10T22:43:22
     end
@@ -507,7 +516,7 @@ RSpec.describe Astronoby::Sun do
 
       setting_time = sun.setting_time(observer: observer)
 
-      expect(setting_time).to eq Time.utc(1991, 3, 14, 17, 50, 37)
+      expect(setting_time).to eq Time.utc(1991, 3, 14, 17, 50, 36)
       # Time from IMCCE: 1991-03-14T17:52:00
     end
   end
@@ -538,7 +547,7 @@ RSpec.describe Astronoby::Sun do
 
       setting_azimuth = sun.setting_azimuth(observer: observer)
 
-      expect(setting_azimuth&.str(:dms)).to eq "+250° 18′ 35.9082″"
+      expect(setting_azimuth&.str(:dms)).to eq "+250° 18′ 37.7414″"
       # Time from IMCCE: +250° 18′
     end
 
@@ -553,7 +562,7 @@ RSpec.describe Astronoby::Sun do
 
       setting_azimuth = sun.setting_azimuth(observer: observer)
 
-      expect(setting_azimuth&.str(:dms)).to eq "+265° 0′ 44.2147″"
+      expect(setting_azimuth&.str(:dms)).to eq "+265° 0′ 26.8208″"
       # Time from IMCCE: +265° 14′
     end
 
@@ -568,7 +577,7 @@ RSpec.describe Astronoby::Sun do
 
       setting_azimuth = sun.setting_azimuth(observer: observer)
 
-      expect(setting_azimuth&.str(:dms)).to eq "+266° 33′ 33.1435″"
+      expect(setting_azimuth&.str(:dms)).to eq "+266° 33′ 29.6448″"
       # Time from IMCCE: +266° 52′
     end
   end
@@ -586,13 +595,13 @@ RSpec.describe Astronoby::Sun do
     #  Title: Practical Astronomy with your Calculator or Spreadsheet
     #  Authors: Peter Duffett-Smith and Jonathan Zwart
     #  Edition: Cambridge University Press
-    #  Chapter: 51 - The equation of time
+    #  Chapter: 51 - The equation of time, p.116
     it "returns the right value of 2010-07-27" do
       date = Date.new(2010, 7, 27)
 
       equation_of_time = described_class.equation_of_time(date: date)
 
-      expect(equation_of_time).to eq(-392)
+      expect(equation_of_time).to eq(-391)
       # Value from Practical Astronomy: 392
     end
 
@@ -600,13 +609,13 @@ RSpec.describe Astronoby::Sun do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.148
     it "returns the right value of 2016-05-05" do
       date = Date.new(2016, 5, 5)
 
       equation_of_time = described_class.equation_of_time(date: date)
 
-      expect(equation_of_time).to eq(199)
+      expect(equation_of_time).to eq(200)
       # Value from Celestial Calculations: 199
     end
 
@@ -614,13 +623,13 @@ RSpec.describe Astronoby::Sun do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.150
     it "returns the right value of 2015-08-09" do
       date = Date.new(2015, 8, 9)
 
       equation_of_time = described_class.equation_of_time(date: date)
 
-      expect(equation_of_time).to eq(-334)
+      expect(equation_of_time).to eq(-332)
       # Value from Celestial Calculations: 337
     end
 
@@ -628,7 +637,7 @@ RSpec.describe Astronoby::Sun do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.150
     it "returns the right value of 2010-05-06" do
       date = Date.new(2010, 5, 6)
 
@@ -642,13 +651,13 @@ RSpec.describe Astronoby::Sun do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.150
     it "returns the right value of 2020-01-01" do
       date = Date.new(2020, 1, 1)
 
       equation_of_time = described_class.equation_of_time(date: date)
 
-      expect(equation_of_time).to eq(-200)
+      expect(equation_of_time).to eq(-198)
       # Value from Celestial Calculations: 187
     end
   end

--- a/spec/astronoby/coordinates/ecliptic_spec.rb
+++ b/spec/astronoby/coordinates/ecliptic_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Astronoby::Coordinates::Ecliptic do
-  describe "#to_equatorial" do
+  describe "#to_true_equatorial" do
     # Source:
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 4 - Orbits and Coordinate Systems
+    #  Chapter: 4 - Orbits and Coordinate Systems, p.95
     context "with real life arguments (book example)" do
       it "computes properly" do
         latitude = Astronoby::Angle.as_dms(1, 12, 0)
@@ -16,13 +16,15 @@ RSpec.describe Astronoby::Coordinates::Ecliptic do
         equatorial_coordinates = described_class.new(
           latitude: latitude,
           longitude: longitude
-        ).to_equatorial(epoch: epoch)
+        ).to_true_equatorial(epoch: epoch)
 
         expect(equatorial_coordinates.right_ascension.str(:hms)).to(
           eq("12h 18m 47.4954s")
+          # Result from the book: 12h 18m 47.5s
         )
         expect(equatorial_coordinates.declination.str(:dms)).to(
           eq("-0° 43′ 35.5098″")
+          # Result from the book: -0° 43′ 35.5″
         )
       end
     end
@@ -31,7 +33,7 @@ RSpec.describe Astronoby::Coordinates::Ecliptic do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 4 - Orbits and Coordinate Systems
+    #  Chapter: 4 - Orbits and Coordinate Systems, p.106
     context "with real life arguments (book example)" do
       it "computes properly" do
         latitude = Astronoby::Angle.zero
@@ -41,13 +43,15 @@ RSpec.describe Astronoby::Coordinates::Ecliptic do
         equatorial_coordinates = described_class.new(
           latitude: latitude,
           longitude: longitude
-        ).to_equatorial(epoch: epoch)
+        ).to_true_equatorial(epoch: epoch)
 
         expect(equatorial_coordinates.right_ascension.str(:hms)).to(
           eq("8h 10m 50.4188s")
+          # Result from the book: 8h 10m 50s
         )
         expect(equatorial_coordinates.declination.str(:dms)).to(
           eq("+20° 2′ 30.795″")
+          # Result from the book: +20° 2′ 31″
         )
       end
     end
@@ -56,7 +60,7 @@ RSpec.describe Astronoby::Coordinates::Ecliptic do
     #  Title: Practical Astronomy with your Calculator or Spreadsheet
     #  Authors: Peter Duffett-Smith and Jonathan Zwart
     #  Edition: Cambridge University Press
-    #  Chapter: 27 - Ecliptic to equatorial coordinate conversion
+    #  Chapter: 27 - Ecliptic to equatorial coordinate conversion, p.52
     context "with real life arguments (book example)" do
       it "computes properly" do
         latitude = Astronoby::Angle.as_dms(4, 52, 31)
@@ -66,13 +70,15 @@ RSpec.describe Astronoby::Coordinates::Ecliptic do
         equatorial_coordinates = described_class.new(
           latitude: latitude,
           longitude: longitude
-        ).to_equatorial(epoch: epoch)
+        ).to_true_equatorial(epoch: epoch)
 
         expect(equatorial_coordinates.right_ascension.str(:hms)).to(
           eq("9h 34m 53.3214s")
+          # Result from the book: 9h 34m 53.32s
         )
         expect(equatorial_coordinates.declination.str(:dms)).to(
           eq("+19° 32′ 6.0105″")
+          # Result from the book: +19° 32′ 6.01″
         )
       end
     end

--- a/spec/astronoby/equinox_solstice_spec.rb
+++ b/spec/astronoby/equinox_solstice_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe Astronoby::EquinoxSolstice do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.143
     it "it returns the time for the 2004 March equinox" do
       year = 2004
 
       equinox = described_class.march_equinox(year)
 
-      expect(equinox).to eq Time.utc(2004, 3, 20, 6, 47, 17)
+      expect(equinox).to eq Time.utc(2004, 3, 20, 6, 47, 24)
       # Time from Celestial Calculations: 2004-03-20T06:42:36
       # Time from Astronomical Algorithms: 2004-03-20T06:49:42
       # Time from IMCCE: 2004-03-20T06:48:38
@@ -34,7 +34,7 @@ RSpec.describe Astronoby::EquinoxSolstice do
 
       equinox = described_class.march_equinox(year)
 
-      expect(equinox).to eq Time.utc(2024, 3, 20, 3, 5, 0)
+      expect(equinox).to eq Time.utc(2024, 3, 20, 3, 5, 8)
       # Time from IMCCE: 2024-03-20T03:06:24
     end
   end
@@ -44,13 +44,13 @@ RSpec.describe Astronoby::EquinoxSolstice do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
+    #  Chapter: 6 - The Sun, p.143
     it "it returns the time for the 2004 June solstice" do
       year = 2004
 
       equinox = described_class.june_solstice(year)
 
-      expect(equinox).to eq Time.utc(2004, 6, 21, 0, 54, 25)
+      expect(equinox).to eq Time.utc(2004, 6, 21, 0, 54, 29)
       # Time from Celestial Calculations: 2004-03-21T00:49:41
       # Time from Astronomical Algorithms: 2004-03-21T00:57:57
       # Time from IMCCE: 2004-06-21T00:56:52
@@ -61,7 +61,7 @@ RSpec.describe Astronoby::EquinoxSolstice do
 
       equinox = described_class.june_solstice(year)
 
-      expect(equinox).to eq Time.utc(2024, 6, 20, 20, 50, 14)
+      expect(equinox).to eq Time.utc(2024, 6, 20, 20, 50, 18)
       # Time from IMCCE: 2024-06-20T20:51:00
     end
   end
@@ -71,13 +71,13 @@ RSpec.describe Astronoby::EquinoxSolstice do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
-    it "it returns the time for the 2024 September equinox" do
+    #  Chapter: 6 - The Sun, p.143
+    it "it returns the time for the 2004 September equinox" do
       year = 2004
 
       equinox = described_class.september_equinox(year)
 
-      expect(equinox).to eq Time.utc(2004, 9, 22, 16, 31, 21)
+      expect(equinox).to eq Time.utc(2004, 9, 22, 16, 31, 14)
       # Time from Celestial Calculations: 2004-09-22T16:30:54
       # Time from Astronomical Algorithms: 2004-09-22T16:27:20
       # Time from IMCCE: 2004-09-22T16:29:50
@@ -88,7 +88,7 @@ RSpec.describe Astronoby::EquinoxSolstice do
 
       equinox = described_class.september_equinox(year)
 
-      expect(equinox).to eq Time.utc(2024, 9, 22, 12, 38, 28)
+      expect(equinox).to eq Time.utc(2024, 9, 22, 12, 38, 20)
       # Time from IMCCE: 2024-09-22T12:43:40
     end
   end
@@ -98,13 +98,13 @@ RSpec.describe Astronoby::EquinoxSolstice do
     #  Title: Celestial Calculations
     #  Author: J. L. Lawrence
     #  Edition: MIT Press
-    #  Chapter: 6 - The Sun
-    it "it returns the time for the 2024 December solstice" do
+    #  Chapter: 6 - The Sun, p.143
+    it "it returns the time for the 2004 December solstice" do
       year = 2004
 
       equinox = described_class.december_solstice(year)
 
-      expect(equinox).to eq Time.utc(2004, 12, 21, 12, 47, 45)
+      expect(equinox).to eq Time.utc(2004, 12, 21, 12, 47, 42)
       # Time from Celestial Calculations: 2004-12-21T12:44:22
       # Time from Astronomical Algorithms: 2004-12-21T12:42:40
       # Time from IMCCE: 2004-12-21T12:41:36
@@ -115,7 +115,7 @@ RSpec.describe Astronoby::EquinoxSolstice do
 
       equinox = described_class.december_solstice(year)
 
-      expect(equinox).to eq Time.utc(2024, 12, 21, 9, 15, 22)
+      expect(equinox).to eq Time.utc(2024, 12, 21, 9, 15, 19)
       # Time from IMCCE: 2024-12-21T09:20:34
     end
   end


### PR DESCRIPTION
I found it hard to compare the results on this library with different sources like the IMCCE, NASA JPL, Heavens Above, etc.

The main reason is the difference of meaning of coordinates. Regarding the Sun, for example, books like Practical Astronomy or Celestial Calculations provide algorithms to calculate coordinates to the date (current epoch). There are in fact different definitions of coordinates:
- Mean coordinates for standard epoch J2000
- Apparent coordinates for standard epoch J2000
- Mean coordinates for the date's epoch
- Apparent coordinates for the date's epoch

While we already have a way to convert equatorial coordinates from one epoch to another, the current algorithms I have access to will provide only Sun ecliptic coordinates for the date's epoch.

I can still manage to make the difference between true and apparent coordinates, which is the purpose of this change.

This change removes `Astronoby::Sun#ecliptic_coordinates` and `Astronoby::Coordinates::Ecliptic#to_equatorial` in favour of the following:
- `Astronoby::Sun#true_ecliptic_coordinates`: true coordinates
- `Astronoby::Sun#apparent_ecliptic_coordinates`: include corrections for nutation and aberration
- `Astronoby::Coordinates::Ecliptic#to_true_equatorial`: true equatorial coordinates for the date
- `Astronoby::Coordinates::Ecliptic#to_apparent_equatorial`: include corrections for true obliquity

```rb
time = Time.utc(1988, 7, 27, 0, 0, 0)
epoch = Astronoby::Epoch.from_time(time)

true_ecliptic_coordinates = Astronoby::Sun.new(epoch: epoch).true_ecliptic_coordinates
true_equatorial_coordinates = ecliptic_coordinates.to_true_equatorial(epoch: epoch)

true_equatorial_coordinates.right_ascension.str(:hms)
# => "8h 26m 3.6131s"

true_equatorial_coordinates.declination.str(:dms)
=> "+19° 12′ 43.1836″"

apparent_ecliptic_coordinates = Astronoby::Sun.new(epoch: epoch).apparent_ecliptic_coordinates
apparent_equatorial_coordinates = ecliptic_coordinates.to_apparent_equatorial(epoch: epoch)

apparent_equatorial_coordinates.right_ascension.str(:hms)
# => "8h 26m 3.7342s"

apparent_equatorial_coordinates.declination.str(:dms)
# => "+19° 12′ 50.2238″"
```

As you can see the difference is very subtle, but my goal is to provide accurate data and more importantly accurate concepts. I know this library still suffers from some approximations, but I aim to correct this problems over time.