### PR TITLE
Drop `Angle#==`

### DIFF
--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -118,20 +118,16 @@ module Astronoby
       radians.zero?
     end
 
-    def ==(other)
-      other.is_a?(self.class) && radians == other.radians
-    end
-    alias_method :eql?, :==
-
     def hash
       [radians, self.class].hash
     end
 
     def <=>(other)
-      return nil unless other.is_a?(self.class)
+      return unless other.is_a?(self.class)
 
       radians <=> other.radians
     end
+    alias_method :eql?, :==
 
     def str(format)
       case format


### PR DESCRIPTION
Including `Comparable` and implementing `#<=>` already covers value equality, so `#==` doesn't need to be implemented.

`#eql?` is still necessary for equality in hashes and sets.

This change also removes the redundant `nil` value from `#<=>` when two objects are not comparable.