### PR TITLE
Rename `Angle::as_*` into `Angle::from_*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ major one is released.
 ### Angle manipulation
 
 ```rb
-angle1 = Astronoby::Angle.as_degrees(90)
-angle2 = Astronoby::Angle.as_radians(Astronoby::Angle::PI / 2)
-angle3 = Astronoby::Angle.as_hours(12)
+angle1 = Astronoby::Angle.from_degrees(90)
+angle2 = Astronoby::Angle.from_radians(Astronoby::Angle::PI / 2)
+angle3 = Astronoby::Angle.from_hours(12)
 
 angle1 == angle2
 # => true
@@ -50,14 +50,14 @@ angle.cos
 
 ```rb
 equatorial = Astronoby::Coordinates::Equatorial.new(
-  right_ascension: Astronoby::Angle.as_hms(17, 43, 54),
-  declination: Astronoby::Angle.as_dms(-22, 10, 0)
+  right_ascension: Astronoby::Angle.from_hms(17, 43, 54),
+  declination: Astronoby::Angle.from_dms(-22, 10, 0)
 )
 
 horizontal = equatorial.to_horizontal(
   time: Time.new(2016, 1, 21, 21, 30, 0, "-05:00"),
-  latitude: Astronoby::Angle.as_degrees(38),
-  longitude: Astronoby::Angle.as_degrees(-78)
+  latitude: Astronoby::Angle.from_degrees(38),
+  longitude: Astronoby::Angle.from_degrees(-78)
 )
 
 horizontal.altitude.str(:dms)
@@ -73,8 +73,8 @@ horizontal.azimuth.str(:dms)
 time = Time.utc(2023, 2, 17, 11, 0, 0)
 epoch = Astronoby::Epoch.from_time(time)
 
-latitude = Astronoby::Angle.as_degrees(48.8566)
-longitude = Astronoby::Angle.as_degrees(2.3522)
+latitude = Astronoby::Angle.from_degrees(48.8566)
+longitude = Astronoby::Angle.from_degrees(2.3522)
 
 sun = Astronoby::Sun.new(epoch: epoch)
 
@@ -96,8 +96,8 @@ horizontal_coordinates.altitude.str(:dms)
 date = Date.new(2015, 2, 5)
 epoch = Astronoby::Epoch.from_time(date)
 observer = Astronoby::Observer.new(
-  latitude: Astronoby::Angle.as_degrees(38),
-  longitude: Astronoby::Angle.as_degrees(-78)
+  latitude: Astronoby::Angle.from_degrees(38),
+  longitude: Astronoby::Angle.from_degrees(-78)
 )
 sun = Astronoby::Sun.new(epoch: epoch)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -37,6 +37,26 @@ Returns the true equatorial coordinates for ths date's epoch.
 Returns the apparent equatorial coordinates for the date's epoch, including
 corrections for the obliquity.
 
+### `Angle::as_radians` renamed into `Angle::from_radians` (#43)
+
+Behaviour not changed.
+
+### `Angle::as_degrees` renamed into `Angle::from_degrees` (#43)
+
+Behaviour not changed.
+
+### `Angle::as_hours` renamed into `Angle::from_hours` (#43)
+
+Behaviour not changed.
+
+### `Angle::as_dms` renamed into `Angle::from_dms` (#43)
+
+Behaviour not changed.
+
+### `Angle::as_hms` renamed into `Angle::from_hms` (#43)
+
+Behaviour not changed.
+
 ## Upgrading from 0.1.0 to 0.2.0
 
 ### `Observer` class added (#29)

--- a/lib/astronoby/aberration.rb
+++ b/lib/astronoby/aberration.rb
@@ -17,13 +17,13 @@ module Astronoby
     #  Edition: Cambridge University Press
     #  Chapter: 36 - Aberration
     def apply
-      delta_longitude = Angle.as_degrees(
+      delta_longitude = Angle.from_degrees(
         -20.5 * (
           sun_longitude - @coordinates.longitude
         ).cos / @coordinates.latitude.cos / 3600
       )
 
-      delta_latitude = Angle.as_degrees(
+      delta_latitude = Angle.from_degrees(
         -20.5 *
         (sun_longitude - @coordinates.longitude).sin *
         @coordinates.latitude.sin / 3600

--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -25,45 +25,45 @@ module Astronoby
         new(0)
       end
 
-      def as_radians(radians)
+      def from_radians(radians)
         normalized_radians = radians.remainder(FULL_CIRCLE_IN_RADIANS)
         new(normalized_radians)
       end
 
-      def as_degrees(degrees)
+      def from_degrees(degrees)
         radians = degrees / PI_IN_DEGREES * PI
-        as_radians(radians)
+        from_radians(radians)
       end
 
-      def as_hours(hours)
+      def from_hours(hours)
         radians = hours * RADIAN_PER_HOUR
-        as_radians(radians)
+        from_radians(radians)
       end
 
-      def as_hms(hour, minute, second)
+      def from_hms(hour, minute, second)
         hours = hour + minute / MINUTES_PER_HOUR + second / SECONDS_PER_HOUR
-        as_hours(hours)
+        from_hours(hours)
       end
 
-      def as_dms(degree, minute, second)
+      def from_dms(degree, minute, second)
         sign = degree.negative? ? -1 : 1
         degrees = degree.abs + minute / MINUTES_PER_HOUR + second / SECONDS_PER_HOUR
-        as_degrees(sign * degrees)
+        from_degrees(sign * degrees)
       end
 
       def asin(ratio)
         radians = Math.asin(ratio)
-        as_radians(radians)
+        from_radians(radians)
       end
 
       def acos(ratio)
         radians = Math.acos(ratio)
-        as_radians(radians)
+        from_radians(radians)
       end
 
       def atan(ratio)
         radians = Math.atan(ratio)
-        as_radians(radians)
+        from_radians(radians)
       end
     end
 
@@ -87,11 +87,11 @@ module Astronoby
     end
 
     def +(other)
-      self.class.as_radians(radians + other.radians)
+      self.class.from_radians(radians + other.radians)
     end
 
     def -(other)
-      self.class.as_radians(@radians - other.radians)
+      self.class.from_radians(@radians - other.radians)
     end
 
     def sin

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -3,7 +3,7 @@
 module Astronoby
   class Sun
     SEMI_MAJOR_AXIS_IN_METERS = 149_598_500_000
-    ANGULAR_DIAMETER = Angle.as_degrees(0.533128)
+    ANGULAR_DIAMETER = Angle.from_degrees(0.533128)
     INTERPOLATION_FACTOR = BigDecimal("24.07")
 
     # Source:
@@ -136,7 +136,9 @@ module Astronoby
 
     # @return [Astronoby::Angle] Apparent Sun's angular size
     def angular_size
-      Angle.as_degrees(ANGULAR_DIAMETER.degrees * distance_angular_size_factor)
+      Angle.from_degrees(
+        ANGULAR_DIAMETER.degrees * distance_angular_size_factor
+      )
     end
 
     # @return [Astronoby::Angle] Sun's true anomaly
@@ -152,19 +154,19 @@ module Astronoby
         (1 + orbital_eccentricity.degrees) / (1 - orbital_eccentricity.degrees)
       ) * Math.tan(eccentric_anomaly.radians / 2)
 
-      Angle.as_degrees((Angle.atan(tan).degrees * 2) % 360)
+      Angle.from_degrees((Angle.atan(tan).degrees * 2) % 360)
     end
 
     # @return [Astronoby::Angle] Sun's longitude at perigee
     def longitude_at_perigee
-      Angle.as_degrees(
+      Angle.from_degrees(
         (281.2208444 + 1.719175 * centuries + 0.000452778 * centuries**2) % 360
       )
     end
 
     # @return [Astronoby::Angle] Sun's orbital eccentricity
     def orbital_eccentricity
-      Angle.as_degrees(
+      Angle.from_degrees(
         (0.01675104 - 0.0000418 * centuries - 0.000000126 * centuries**2) % 360
       )
     end
@@ -172,13 +174,13 @@ module Astronoby
     private
 
     def true_longitude
-      Angle.as_degrees(
+      Angle.from_degrees(
         (true_anomaly + longitude_at_perigee).degrees % 360
       )
     end
 
     def mean_anomaly
-      Angle.as_degrees(
+      Angle.from_degrees(
         (longitude_at_base_epoch - longitude_at_perigee).degrees % 360
       )
     end
@@ -192,7 +194,7 @@ module Astronoby
     end
 
     def longitude_at_base_epoch
-      Angle.as_degrees(
+      Angle.from_degrees(
         (279.6966778 + 36000.76892 * centuries + 0.0003025 * centuries**2) % 360
       )
     end
@@ -210,7 +212,7 @@ module Astronoby
       sun_at_midnight = self.class.new(epoch: epoch)
       shift = Body::DEFAULT_REFRACTION_VERTICAL_SHIFT +
         GeocentricParallax.angle(distance: sun_at_midnight.earth_distance) +
-        Angle.as_degrees(sun_at_midnight.angular_size.degrees / 2)
+        Angle.from_degrees(sun_at_midnight.angular_size.degrees / 2)
       ecliptic_coordinates = sun_at_midnight.apparent_ecliptic_coordinates
       equatorial_coordinates = ecliptic_coordinates
         .to_apparent_equatorial(epoch: epoch)
@@ -240,7 +242,7 @@ module Astronoby
     def vertical_shift
       Astronoby::Body::DEFAULT_REFRACTION_VERTICAL_SHIFT +
         Astronoby::GeocentricParallax.angle(distance: earth_distance) +
-        Astronoby::Angle.as_degrees(angular_size.degrees / 2)
+        Astronoby::Angle.from_degrees(angular_size.degrees / 2)
     end
   end
 end

--- a/lib/astronoby/body.rb
+++ b/lib/astronoby/body.rb
@@ -2,7 +2,7 @@
 
 module Astronoby
   class Body
-    DEFAULT_REFRACTION_VERTICAL_SHIFT = Angle.as_dms(0, 34, 0)
+    DEFAULT_REFRACTION_VERTICAL_SHIFT = Angle.from_dms(0, 34, 0)
     RISING_SETTING_HOUR_ANGLE_RATIO_RANGE = (-1..1)
 
     def initialize(equatorial_coordinates)
@@ -80,7 +80,7 @@ module Astronoby
       vertical_shift: nil
     )
       time_ratio = time_ratio(latitude, apparent, vertical_shift)
-      return nil unless RISING_SETTING_HOUR_ANGLE_RATIO_RANGE.cover?(time_ratio)
+      return unless RISING_SETTING_HOUR_ANGLE_RATIO_RANGE.cover?(time_ratio)
 
       hour_angle = Angle.acos(time_ratio)
       local_sidereal_time = LocalSiderealTime.new(
@@ -108,7 +108,7 @@ module Astronoby
 
       azimuth_ratio = azimuth_ratio(latitude, apparent, vertical_shift)
 
-      Angle.as_degrees(360 - Angle.acos(azimuth_ratio).degrees)
+      Angle.from_degrees(360 - Angle.acos(azimuth_ratio).degrees)
     end
 
     private

--- a/lib/astronoby/coordinates/ecliptic.rb
+++ b/lib/astronoby/coordinates/ecliptic.rb
@@ -29,11 +29,11 @@ module Astronoby
       private
 
       def to_equatorial(obliquity:)
-        y = Angle.as_radians(
+        y = Angle.from_radians(
           @longitude.sin * obliquity.cos -
             @latitude.tan * obliquity.sin
         )
-        x = Angle.as_radians(@longitude.cos)
+        x = Angle.from_radians(@longitude.cos)
         r = Angle.atan(y.radians / x.radians)
         right_ascension = Util::Trigonometry.adjustement_for_arctangent(y, x, r)
 

--- a/lib/astronoby/coordinates/equatorial.rb
+++ b/lib/astronoby/coordinates/equatorial.rb
@@ -25,7 +25,7 @@ module Astronoby
         ha = (lst.time - @right_ascension.hours)
         ha += 24 if ha.negative?
 
-        Angle.as_hours(ha)
+        Angle.from_hours(ha)
       end
 
       def to_horizontal(time:, latitude:, longitude:)
@@ -39,7 +39,7 @@ module Astronoby
         azimuth = Angle.acos(t2)
 
         if ha.sin.positive?
-          azimuth = Angle.as_degrees(BigDecimal("360") - azimuth.degrees)
+          azimuth = Angle.from_degrees(BigDecimal("360") - azimuth.degrees)
         end
 
         Horizontal.new(
@@ -58,11 +58,11 @@ module Astronoby
       def to_ecliptic(epoch:)
         mean_obliquity = MeanObliquity.for_epoch(epoch)
 
-        y = Angle.as_radians(
+        y = Angle.from_radians(
           @right_ascension.sin * mean_obliquity.cos +
           @declination.tan * mean_obliquity.sin
         )
-        x = Angle.as_radians(@right_ascension.cos)
+        x = Angle.from_radians(@right_ascension.cos)
         r = Angle.atan(y.radians / x.radians)
         longitude = Util::Trigonometry.adjustement_for_arctangent(y, x, r)
 

--- a/lib/astronoby/coordinates/horizontal.rb
+++ b/lib/astronoby/coordinates/horizontal.rb
@@ -31,17 +31,17 @@ module Astronoby
 
         if @azimuth.sin.positive?
           hour_angle_degrees = Angle
-            .as_degrees(BigDecimal("360") - hour_angle_degrees)
+            .from_degrees(BigDecimal("360") - hour_angle_degrees)
             .degrees
         end
 
-        hour_angle_hours = Angle.as_degrees(hour_angle_degrees).hours
+        hour_angle_hours = Angle.from_degrees(hour_angle_degrees).hours
         lst = GreenwichSiderealTime
           .from_utc(time.utc)
           .to_lst(longitude: @longitude)
         right_ascension_decimal = lst.time - hour_angle_hours
         right_ascension_decimal += 24 if right_ascension_decimal.negative?
-        right_ascension = Angle.as_hours(right_ascension_decimal)
+        right_ascension = Angle.from_hours(right_ascension_decimal)
 
         Equatorial.new(
           right_ascension: right_ascension,

--- a/lib/astronoby/equinox_solstice.rb
+++ b/lib/astronoby/equinox_solstice.rb
@@ -102,13 +102,13 @@ module Astronoby
 
     def compute
       t = (julian_day - Epoch::J2000) / Epoch::DAYS_PER_JULIAN_CENTURY
-      w = Angle.as_degrees(35999.373 * t) - Angle.as_degrees(2.47)
+      w = Angle.from_degrees(35999.373 * t) - Angle.from_degrees(2.47)
       delta = 1 +
         0.0334 * w.cos +
-        0.0007 * Angle.as_degrees(w.degrees * 2).cos
+        0.0007 * Angle.from_degrees(w.degrees * 2).cos
 
       s = PERIODIC_TERMS.sum do |a, b, c|
-        a * (Angle.as_degrees(b) + Angle.as_degrees(c * t)).cos
+        a * (Angle.from_degrees(b) + Angle.from_degrees(c * t)).cos
       end
 
       delta_days = 0.00001 * s / delta
@@ -133,7 +133,7 @@ module Astronoby
       sun = Sun.new(epoch: epoch)
       longitude = sun.apparent_ecliptic_coordinates.longitude
 
-      58 * Angle.as_degrees(@event * 90 - longitude.degrees).sin
+      58 * Angle.from_degrees(@event * 90 - longitude.degrees).sin
     end
   end
 end

--- a/lib/astronoby/mean_obliquity.rb
+++ b/lib/astronoby/mean_obliquity.rb
@@ -16,7 +16,7 @@ module Astronoby
 
       t = (epoch - EPOCH_OF_REFERENCE) / Epoch::DAYS_PER_JULIAN_CENTURY
 
-      Angle.as_degrees(
+      Angle.from_degrees(
         obliquity_of_reference.degrees - (
           46.815 * t -
           0.0006 * t * t +
@@ -26,7 +26,7 @@ module Astronoby
     end
 
     def self.obliquity_of_reference
-      Angle.as_dms(23, 26, 21.45)
+      Angle.from_dms(23, 26, 21.45)
     end
   end
 end

--- a/lib/astronoby/nutation.rb
+++ b/lib/astronoby/nutation.rb
@@ -21,7 +21,7 @@ module Astronoby
     end
 
     def for_ecliptic_longitude
-      Angle.as_dms(
+      Angle.from_dms(
         0,
         0,
         (
@@ -32,7 +32,7 @@ module Astronoby
     end
 
     def for_obliquity_of_the_ecliptic
-      Angle.as_dms(
+      Angle.from_dms(
         0,
         0,
         (
@@ -49,13 +49,13 @@ module Astronoby
     end
 
     def sun_mean_longitude
-      Angle.as_degrees(
+      Angle.from_degrees(
         (279.6967 + 360.0 * (centuries_a - centuries_a.to_i)) % 360
       )
     end
 
     def moon_ascending_node_longitude
-      Angle.as_degrees(
+      Angle.from_degrees(
         (259.1833 - 360.0 * (centuries_b - centuries_b.to_i)) % 360
       )
     end

--- a/lib/astronoby/precession.rb
+++ b/lib/astronoby/precession.rb
@@ -33,8 +33,8 @@ module Astronoby
 
       Coordinates::Equatorial.new(
         right_ascension: Util::Trigonometry.adjustement_for_arctangent(
-          Angle.as_radians(w[1]),
-          Angle.as_radians(w[0]),
+          Angle.from_radians(w[1]),
+          Angle.from_radians(w[0]),
           Angle.atan(w[1] / w[0])
         ),
         declination: Angle.asin(w[2]),
@@ -47,13 +47,13 @@ module Astronoby
     def matrix_for_epoch(epoch)
       t = (epoch - Epoch::DEFAULT_EPOCH) / Epoch::DAYS_PER_JULIAN_CENTURY
 
-      zeta = Angle.as_degrees(
+      zeta = Angle.from_degrees(
         0.6406161 * t + 0.0000839 * t * t + 0.000005 * t * t * t
       )
-      z = Angle.as_degrees(
+      z = Angle.from_degrees(
         0.6406161 * t + 0.0003041 * t * t + 0.0000051 * t * t * t
       )
-      theta = Angle.as_degrees(
+      theta = Angle.from_degrees(
         0.5567530 * t - 0.0001185 * t * t - 0.0000116 * t * t * t
       )
 

--- a/lib/astronoby/refraction.rb
+++ b/lib/astronoby/refraction.rb
@@ -2,8 +2,8 @@
 
 module Astronoby
   class Refraction
-    LOW_ALTITUDE_BODY_ANGLE = Angle.as_degrees(15)
-    ZENITH = Angle.as_degrees(90)
+    LOW_ALTITUDE_BODY_ANGLE = Angle.from_degrees(15)
+    ZENITH = Angle.from_degrees(90)
 
     def self.angle(coordinates:, observer:)
       new(coordinates, observer).refraction_angle
@@ -56,7 +56,7 @@ module Astronoby
 
     def high_altitude_angle
       zenith_angle = ZENITH - @coordinates.altitude
-      Angle.as_degrees(0.00452 * pressure * zenith_angle.tan / temperature)
+      Angle.from_degrees(0.00452 * pressure * zenith_angle.tan / temperature)
     end
 
     def low_altitude_angle
@@ -67,7 +67,7 @@ module Astronoby
         1 + 0.505 * altitude_in_degrees + 0.0845 * altitude_in_degrees**2
       )
 
-      Angle.as_degrees(term1 / term2)
+      Angle.from_degrees(term1 / term2)
     end
   end
 end

--- a/lib/astronoby/util/astrodynamics.rb
+++ b/lib/astronoby/util/astrodynamics.rb
@@ -42,7 +42,7 @@ module Astronoby
                 previous_solution &&
                 (solution - previous_solution).abs <= precision
               )
-            return Angle.as_radians(solution)
+            return Angle.from_radians(solution)
           end
 
           eccentric_anomaly_newton_raphson(
@@ -51,7 +51,7 @@ module Astronoby
             precision,
             maximum_iteration_count,
             current_iteration + 1,
-            Angle.as_radians(solution)
+            Angle.from_radians(solution)
           )
         end
       end

--- a/lib/astronoby/util/trigonometry.rb
+++ b/lib/astronoby/util/trigonometry.rb
@@ -15,10 +15,10 @@ module Astronoby
           return angle if y.positive? && x.positive?
 
           if y.negative? && x.positive?
-            return Angle.as_degrees(angle.degrees + 360)
+            return Angle.from_degrees(angle.degrees + 360)
           end
 
-          Angle.as_degrees(angle.degrees + 180)
+          Angle.from_degrees(angle.degrees + 180)
         end
       end
     end

--- a/spec/astronoby/aberration_spec.rb
+++ b/spec/astronoby/aberration_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Astronoby::Aberration do
   describe "::for_ecliptic_coordinates" do
     it "returns apparent ecliptic coordinates" do
       true_coordinates = Astronoby::Coordinates::Ecliptic.new(
-        latitude: Astronoby::Angle.as_dms(20, 30, 40),
-        longitude: Astronoby::Angle.as_dms(30, 40, 50)
+        latitude: Astronoby::Angle.from_dms(20, 30, 40),
+        longitude: Astronoby::Angle.from_dms(30, 40, 50)
       )
 
       apparent_coordinates = described_class.for_ecliptic_coordinates(
@@ -29,8 +29,8 @@ RSpec.describe Astronoby::Aberration do
     #  Chapter: 36 - Aberration
     it "computes accurate apparent coordinates" do
       true_coordinates = Astronoby::Coordinates::Ecliptic.new(
-        latitude: Astronoby::Angle.as_dms(-1, 32, 56.4),
-        longitude: Astronoby::Angle.as_dms(352, 37, 10.1)
+        latitude: Astronoby::Angle.from_dms(-1, 32, 56.4),
+        longitude: Astronoby::Angle.from_dms(352, 37, 10.1)
       )
       time = Time.utc(1988, 9, 8)
       epoch = Astronoby::Epoch.from_time(time)

--- a/spec/astronoby/angle_spec.rb
+++ b/spec/astronoby/angle_spec.rb
@@ -10,57 +10,58 @@ RSpec.describe Astronoby::Angle do
           end
         end
 
-        expect { described_class.as_degrees(180).clear }.to raise_error(FrozenError)
+        expect { described_class.from_degrees(180).clear }
+          .to raise_error(FrozenError)
       end
     end
   end
 
-  describe "::as_radians" do
+  describe "::from_radians" do
     it "returns an Angle object" do
-      expect(described_class.as_radians(described_class::PI))
+      expect(described_class.from_radians(described_class::PI))
         .to be_a(described_class)
     end
 
     it "normalizes the angle" do
-      expect(described_class.as_radians(2 * described_class::PI).radians)
+      expect(described_class.from_radians(2 * described_class::PI).radians)
         .to eq 0
 
-      expect(described_class.as_radians(3 * described_class::PI).radians)
+      expect(described_class.from_radians(3 * described_class::PI).radians)
         .to eq described_class::PI
 
-      expect(described_class.as_radians(-5 * described_class::PI).radians)
+      expect(described_class.from_radians(-5 * described_class::PI).radians)
         .to eq(-described_class::PI)
 
-      expect(described_class.as_radians(described_class::PI / 2).radians)
+      expect(described_class.from_radians(described_class::PI / 2).radians)
         .to eq described_class::PI / 2
     end
   end
 
-  describe "::as_degrees" do
+  describe "::from_degrees" do
     it "returns an Angle object" do
-      expect(described_class.as_degrees(180)).to be_a(described_class)
+      expect(described_class.from_degrees(180)).to be_a(described_class)
     end
 
     it "normalizes the angle" do
-      expect(described_class.as_degrees(360).degrees.round).to eq 0
-      expect(described_class.as_degrees(365).degrees.round).to eq 5
-      expect(described_class.as_degrees(-365).degrees.round).to eq(-5)
-      expect(described_class.as_degrees(70).degrees.round).to eq 70
-      expect(described_class.as_degrees(-70).degrees.round).to eq(-70)
+      expect(described_class.from_degrees(360).degrees.round).to eq 0
+      expect(described_class.from_degrees(365).degrees.round).to eq 5
+      expect(described_class.from_degrees(-365).degrees.round).to eq(-5)
+      expect(described_class.from_degrees(70).degrees.round).to eq 70
+      expect(described_class.from_degrees(-70).degrees.round).to eq(-70)
     end
   end
 
-  describe "::as_hours" do
+  describe "::from_hours" do
     it "returns an Angle object" do
-      expect(described_class.as_hours(23)).to be_a(described_class)
+      expect(described_class.from_hours(23)).to be_a(described_class)
     end
 
     it "normalizes the angle" do
-      expect(described_class.as_hours(24).hours.round).to eq 0
-      expect(described_class.as_hours(26).hours.round).to eq 2
-      expect(described_class.as_hours(-26).hours.round).to eq(-2)
-      expect(described_class.as_hours(23).hours.round).to eq 23
-      expect(described_class.as_hours(-23).hours.round).to eq(-23)
+      expect(described_class.from_hours(24).hours.round).to eq 0
+      expect(described_class.from_hours(26).hours.round).to eq 2
+      expect(described_class.from_hours(-26).hours.round).to eq(-2)
+      expect(described_class.from_hours(23).hours.round).to eq 23
+      expect(described_class.from_hours(-23).hours.round).to eq(-23)
     end
   end
 
@@ -118,7 +119,7 @@ RSpec.describe Astronoby::Angle do
 
     context "when the angle is initialized from degrees" do
       it "returns the angle value in radian unit" do
-        radians = described_class.as_degrees(180).radians
+        radians = described_class.from_degrees(180).radians
 
         expect(radians).to eq described_class::PI
       end
@@ -126,7 +127,7 @@ RSpec.describe Astronoby::Angle do
 
     context "when the angle is initialized from hours" do
       it "returns the angle value in radian unit within fixed precision" do
-        radians = described_class.as_hours(12).radians
+        radians = described_class.from_hours(12).radians
 
         expect(radians)
           .to be_within(10**-described_class::PRECISION).of(described_class::PI)
@@ -136,14 +137,14 @@ RSpec.describe Astronoby::Angle do
 
   describe "#degrees" do
     it "returns the angle value in degree unit" do
-      degrees = described_class.as_degrees(180).degrees
+      degrees = described_class.from_degrees(180).degrees
 
       expect(degrees).to eq 180
     end
 
     context "when the angle is initialized from radians" do
       it "returns the angle value in degree unit" do
-        degrees = described_class.as_radians(described_class::PI).degrees
+        degrees = described_class.from_radians(described_class::PI).degrees
 
         expect(degrees).to eq 180
       end
@@ -151,7 +152,7 @@ RSpec.describe Astronoby::Angle do
 
     context "when the angle is initialized from hours" do
       it "returns the angle value in degree unit within fixed precision" do
-        degrees = described_class.as_hours(12).degrees
+        degrees = described_class.from_hours(12).degrees
 
         expect(degrees).to be_within(10**-described_class::PRECISION).of(180)
       end
@@ -160,14 +161,14 @@ RSpec.describe Astronoby::Angle do
 
   describe "#hours" do
     it "returns the angle value in degree unit within fixed precision" do
-      hours = described_class.as_hours(12).hours
+      hours = described_class.from_hours(12).hours
 
       expect(hours).to eq 12
     end
 
     context "when the angle is initialized from radians" do
       it "returns the angle value in degree unit within fixed precision" do
-        hours = described_class.as_radians(described_class::PI).hours
+        hours = described_class.from_radians(described_class::PI).hours
 
         expect(hours).to be_within(10**-described_class::PRECISION).of(12)
       end
@@ -175,7 +176,7 @@ RSpec.describe Astronoby::Angle do
 
     context "when the angle is initialized from degrees" do
       it "returns the angle value in degree unit within fixed precision" do
-        hours = described_class.as_degrees(180).hours
+        hours = described_class.from_degrees(180).hours
 
         expect(hours).to be_within(10**-described_class::PRECISION).of(12)
       end
@@ -184,8 +185,8 @@ RSpec.describe Astronoby::Angle do
 
   describe "#+" do
     it "returns a new angle with a value of the two angles added" do
-      angle_1 = described_class.as_radians(described_class::PI)
-      angle_2 = described_class.as_degrees(45)
+      angle_1 = described_class.from_radians(described_class::PI)
+      angle_2 = described_class.from_degrees(45)
 
       new_angle = angle_1 + angle_2
 
@@ -195,8 +196,8 @@ RSpec.describe Astronoby::Angle do
 
   describe "#-" do
     it "returns a new angle with a value of the two angles substracted" do
-      angle_1 = described_class.as_radians(described_class::PI)
-      angle_2 = described_class.as_degrees(45)
+      angle_1 = described_class.from_radians(described_class::PI)
+      angle_2 = described_class.from_degrees(45)
 
       new_angle = angle_1 - angle_2
 
@@ -207,7 +208,7 @@ RSpec.describe Astronoby::Angle do
   describe "#sin" do
     it "returns the sine value of the angle" do
       radians = described_class::PI / 6
-      angle = described_class.as_radians(radians)
+      angle = described_class.from_radians(radians)
 
       sine = angle.sin.ceil(described_class::PRECISION)
 
@@ -218,7 +219,7 @@ RSpec.describe Astronoby::Angle do
   describe "#cos" do
     it "returns the cosine value of the angle" do
       radians = described_class::PI / 3
-      angle = described_class.as_radians(radians)
+      angle = described_class.from_radians(radians)
 
       cosine = angle.cos.ceil(described_class::PRECISION)
 
@@ -229,7 +230,7 @@ RSpec.describe Astronoby::Angle do
   describe "#tan" do
     it "returns the tangent value of the angle" do
       radians = described_class::PI / 4
-      angle = described_class.as_radians(radians)
+      angle = described_class.from_radians(radians)
 
       tangent = angle.tan.ceil(described_class::PRECISION)
 
@@ -239,57 +240,57 @@ RSpec.describe Astronoby::Angle do
 
   describe "#positive?" do
     it "returns true when the angle is positive" do
-      expect(described_class.as_degrees(90).positive?).to be true
+      expect(described_class.from_degrees(90).positive?).to be true
     end
 
     it "returns false when the angle is negative" do
-      expect(described_class.as_degrees(-90).positive?).to be false
+      expect(described_class.from_degrees(-90).positive?).to be false
     end
 
     it "returns famse when the angle has a zero value" do
-      expect(described_class.as_degrees(0).positive?).to be false
+      expect(described_class.from_degrees(0).positive?).to be false
     end
   end
 
   describe "#negative?" do
     it "returns false when the angle is positive" do
-      expect(described_class.as_degrees(90).negative?).to be false
+      expect(described_class.from_degrees(90).negative?).to be false
     end
 
     it "returns true when the angle is negative" do
-      expect(described_class.as_degrees(-90).negative?).to be true
+      expect(described_class.from_degrees(-90).negative?).to be true
     end
 
     it "returns false when the angle has a zero value" do
-      expect(described_class.as_degrees(0).negative?).to be false
+      expect(described_class.from_degrees(0).negative?).to be false
     end
   end
 
   describe "#zero?" do
     it "returns false when the angle is positive" do
-      expect(described_class.as_degrees(90).zero?).to be false
+      expect(described_class.from_degrees(90).zero?).to be false
     end
 
     it "returns false when the angle is negative" do
-      expect(described_class.as_degrees(-90).zero?).to be false
+      expect(described_class.from_degrees(-90).zero?).to be false
     end
 
     it "returns true when the angle has a zero value" do
-      expect(described_class.as_degrees(0).zero?).to be true
+      expect(described_class.from_degrees(0).zero?).to be true
     end
   end
 
   describe "equivalence (#==)" do
     it "returns true when the angle is equivalent" do
-      angle1 = Astronoby::Angle.as_degrees(180)
-      angle2 = Astronoby::Angle.as_degrees(180)
+      angle1 = Astronoby::Angle.from_degrees(180)
+      angle2 = Astronoby::Angle.from_degrees(180)
 
       expect(angle1).to eq angle2
     end
 
     it "returns true when the angle is not equivalent" do
-      angle1 = Astronoby::Angle.as_degrees(180)
-      angle2 = Astronoby::Angle.as_degrees(90)
+      angle1 = Astronoby::Angle.from_degrees(180)
+      angle2 = Astronoby::Angle.from_degrees(90)
 
       expect(angle1).not_to eq angle2
     end
@@ -297,16 +298,16 @@ RSpec.describe Astronoby::Angle do
 
   describe "hash equality" do
     it "makes an angle foundable as a Hash key" do
-      angle1 = Astronoby::Angle.as_degrees(180)
-      angle1_bis = Astronoby::Angle.as_degrees(180)
+      angle1 = Astronoby::Angle.from_degrees(180)
+      angle1_bis = Astronoby::Angle.from_degrees(180)
       map = {angle1 => :angle}
 
       expect(map[angle1_bis]).to eq :angle
     end
 
     it "makes an angle foundable in a Set" do
-      angle1 = Astronoby::Angle.as_degrees(180)
-      angle1_bis = Astronoby::Angle.as_degrees(180)
+      angle1 = Astronoby::Angle.from_degrees(180)
+      angle1_bis = Astronoby::Angle.from_degrees(180)
       set = Set.new([angle1])
 
       expect(set.include?(angle1_bis)).to be true
@@ -315,12 +316,12 @@ RSpec.describe Astronoby::Angle do
 
   describe "comparison" do
     it "handles comparison of angles" do
-      angle = described_class.as_degrees(10)
-      same_angle = described_class.as_degrees(10)
-      greater_angle = described_class.as_radians(described_class::PI)
-      smaller_angle = described_class.as_degrees(5)
-      way_greater_angle = described_class.as_degrees(365)
-      negative_angle = described_class.as_radians(-described_class::PI)
+      angle = described_class.from_degrees(10)
+      same_angle = described_class.from_degrees(10)
+      greater_angle = described_class.from_radians(described_class::PI)
+      smaller_angle = described_class.from_degrees(5)
+      way_greater_angle = described_class.from_degrees(365)
+      negative_angle = described_class.from_radians(-described_class::PI)
 
       expect(angle == same_angle).to be true
       expect(angle != same_angle).to be false
@@ -351,7 +352,7 @@ RSpec.describe Astronoby::Angle do
     end
 
     it "doesn't support comparison of angles with other types" do
-      angle = Astronoby::Angle.as_degrees(10)
+      angle = Astronoby::Angle.from_degrees(10)
 
       expect(angle <=> 10).to be_nil
     end
@@ -359,7 +360,7 @@ RSpec.describe Astronoby::Angle do
 
   describe "#str" do
     it "returns a String" do
-      angle = described_class.as_degrees(180)
+      angle = described_class.from_degrees(180)
 
       expect(angle.str(:dms)).to be_a(String)
     end
@@ -367,7 +368,7 @@ RSpec.describe Astronoby::Angle do
     describe "to the DMS format" do
       context "when the angle is positive" do
         it "properly formats the angle" do
-          angle = described_class.as_degrees(10.2958)
+          angle = described_class.from_degrees(10.2958)
 
           expect(angle.str(:dms)).to eq "+10° 17′ 44.88″"
         end
@@ -375,7 +376,7 @@ RSpec.describe Astronoby::Angle do
 
       context "when the angle is negative" do
         it "properly formats the angle" do
-          angle = described_class.as_degrees(-10.2958)
+          angle = described_class.from_degrees(-10.2958)
 
           expect(angle.str(:dms)).to eq "-10° 17′ 44.88″"
         end
@@ -384,7 +385,7 @@ RSpec.describe Astronoby::Angle do
 
     describe "to the HMS format" do
       it "properly formats the angle" do
-        angle = described_class.as_hours(12.345678)
+        angle = described_class.from_hours(12.345678)
 
         expect(angle.str(:hms)).to eq "12h 20m 44.4408s"
       end
@@ -392,10 +393,12 @@ RSpec.describe Astronoby::Angle do
 
     describe "to an unsupported format" do
       it "raises an UnsupportedFormatError exception" do
-        angle = described_class.as_degrees(180)
+        angle = described_class.from_degrees(180)
 
-        expect { angle.str(:unknown) }
-          .to raise_error(Astronoby::UnsupportedFormatError, "Expected a format between dms, hms, got unknown")
+        expect { angle.str(:unknown) }.to raise_error(
+          Astronoby::UnsupportedFormatError,
+          "Expected a format between dms, hms, got unknown"
+        )
       end
     end
   end

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe Astronoby::Sun do
       coordinates = described_class
         .new(epoch: epoch)
         .horizontal_coordinates(
-          latitude: Astronoby::Angle.as_degrees(-20),
-          longitude: Astronoby::Angle.as_degrees(-30)
+          latitude: Astronoby::Angle.from_degrees(-20),
+          longitude: Astronoby::Angle.from_degrees(-30)
         )
 
       expect(coordinates).to be_a(Astronoby::Coordinates::Horizontal)
@@ -119,8 +119,8 @@ RSpec.describe Astronoby::Sun do
       sun = described_class.new(epoch: epoch)
 
       horizontal_coordinates = sun.horizontal_coordinates(
-        latitude: Astronoby::Angle.as_degrees(38),
-        longitude: Astronoby::Angle.as_degrees(-78)
+        latitude: Astronoby::Angle.from_degrees(38),
+        longitude: Astronoby::Angle.from_degrees(-78)
       )
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
@@ -144,8 +144,8 @@ RSpec.describe Astronoby::Sun do
       sun = described_class.new(epoch: epoch)
 
       horizontal_coordinates = sun.horizontal_coordinates(
-        latitude: Astronoby::Angle.as_degrees(30),
-        longitude: Astronoby::Angle.as_degrees(-95)
+        latitude: Astronoby::Angle.from_degrees(30),
+        longitude: Astronoby::Angle.from_degrees(-95)
       )
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
@@ -169,8 +169,8 @@ RSpec.describe Astronoby::Sun do
       sun = described_class.new(epoch: epoch)
 
       horizontal_coordinates = sun.horizontal_coordinates(
-        latitude: Astronoby::Angle.as_degrees(-20),
-        longitude: Astronoby::Angle.as_degrees(-30)
+        latitude: Astronoby::Angle.from_degrees(-20),
+        longitude: Astronoby::Angle.from_degrees(-30)
       )
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
@@ -338,8 +338,8 @@ RSpec.describe Astronoby::Sun do
       date = Date.new(2015, 2, 5)
       epoch = Astronoby::Epoch.from_time(date)
       observer = Astronoby::Observer.new(
-        latitude: Astronoby::Angle.as_degrees(38),
-        longitude: Astronoby::Angle.as_degrees(-78)
+        latitude: Astronoby::Angle.from_degrees(38),
+        longitude: Astronoby::Angle.from_degrees(-78)
       )
       sun = described_class.new(epoch: epoch)
 
@@ -359,8 +359,8 @@ RSpec.describe Astronoby::Sun do
       date = Date.new(1986, 3, 10)
       epoch = Astronoby::Epoch.from_time(date)
       observer = Astronoby::Observer.new(
-        latitude: Astronoby::Angle.as_degrees(42.37),
-        longitude: Astronoby::Angle.as_degrees(-71.05)
+        latitude: Astronoby::Angle.from_degrees(42.37),
+        longitude: Astronoby::Angle.from_degrees(-71.05)
       )
       sun = described_class.new(epoch: epoch)
 
@@ -375,8 +375,8 @@ RSpec.describe Astronoby::Sun do
       date = Date.new(1991, 3, 14)
       epoch = Astronoby::Epoch.from_time(date)
       observer = Astronoby::Observer.new(
-        latitude: Astronoby::Angle.as_degrees(48.8566),
-        longitude: Astronoby::Angle.as_degrees(2.3522)
+        latitude: Astronoby::Angle.from_degrees(48.8566),
+        longitude: Astronoby::Angle.from_degrees(2.3522)
       )
       sun = described_class.new(epoch: epoch)
 
@@ -406,8 +406,8 @@ RSpec.describe Astronoby::Sun do
       date = Date.new(2015, 2, 5)
       epoch = Astronoby::Epoch.from_time(date)
       observer = Astronoby::Observer.new(
-        latitude: Astronoby::Angle.as_degrees(38),
-        longitude: Astronoby::Angle.as_degrees(-78)
+        latitude: Astronoby::Angle.from_degrees(38),
+        longitude: Astronoby::Angle.from_degrees(-78)
       )
       sun = described_class.new(epoch: epoch)
 
@@ -421,8 +421,8 @@ RSpec.describe Astronoby::Sun do
       date = Date.new(1986, 3, 10)
       epoch = Astronoby::Epoch.from_time(date)
       observer = Astronoby::Observer.new(
-        latitude: Astronoby::Angle.as_degrees(42.37),
-        longitude: Astronoby::Angle.as_degrees(-71.05)
+        latitude: Astronoby::Angle.from_degrees(42.37),
+        longitude: Astronoby::Angle.from_degrees(-71.05)
       )
       sun = described_class.new(epoch: epoch)
 
@@ -436,8 +436,8 @@ RSpec.describe Astronoby::Sun do
       date = Date.new(1991, 3, 14)
       epoch = Astronoby::Epoch.from_time(date)
       observer = Astronoby::Observer.new(
-        latitude: Astronoby::Angle.as_degrees(48.8566),
-        longitude: Astronoby::Angle.as_degrees(2.3522)
+        latitude: Astronoby::Angle.from_degrees(48.8566),
+        longitude: Astronoby::Angle.from_degrees(2.3522)
       )
       sun = described_class.new(epoch: epoch)
 
@@ -472,8 +472,8 @@ RSpec.describe Astronoby::Sun do
       date = Date.new(2015, 2, 5)
       epoch = Astronoby::Epoch.from_time(date)
       observer = Astronoby::Observer.new(
-        latitude: Astronoby::Angle.as_degrees(38),
-        longitude: Astronoby::Angle.as_degrees(-78)
+        latitude: Astronoby::Angle.from_degrees(38),
+        longitude: Astronoby::Angle.from_degrees(-78)
       )
       sun = described_class.new(epoch: epoch)
 
@@ -493,8 +493,8 @@ RSpec.describe Astronoby::Sun do
       date = Date.new(1986, 3, 10)
       epoch = Astronoby::Epoch.from_time(date)
       observer = Astronoby::Observer.new(
-        latitude: Astronoby::Angle.as_degrees(42.37),
-        longitude: Astronoby::Angle.as_degrees(-71.05)
+        latitude: Astronoby::Angle.from_degrees(42.37),
+        longitude: Astronoby::Angle.from_degrees(-71.05)
       )
       sun = described_class.new(epoch: epoch)
 
@@ -509,8 +509,8 @@ RSpec.describe Astronoby::Sun do
       date = Date.new(1991, 3, 14)
       epoch = Astronoby::Epoch.from_time(date)
       observer = Astronoby::Observer.new(
-        latitude: Astronoby::Angle.as_degrees(48.8566),
-        longitude: Astronoby::Angle.as_degrees(2.3522)
+        latitude: Astronoby::Angle.from_degrees(48.8566),
+        longitude: Astronoby::Angle.from_degrees(2.3522)
       )
       sun = described_class.new(epoch: epoch)
 
@@ -540,8 +540,8 @@ RSpec.describe Astronoby::Sun do
       date = Date.new(2015, 2, 5)
       epoch = Astronoby::Epoch.from_time(date)
       observer = Astronoby::Observer.new(
-        latitude: Astronoby::Angle.as_degrees(38),
-        longitude: Astronoby::Angle.as_degrees(-78)
+        latitude: Astronoby::Angle.from_degrees(38),
+        longitude: Astronoby::Angle.from_degrees(-78)
       )
       sun = described_class.new(epoch: epoch)
 
@@ -555,8 +555,8 @@ RSpec.describe Astronoby::Sun do
       date = Date.new(1986, 3, 10)
       epoch = Astronoby::Epoch.from_time(date)
       observer = Astronoby::Observer.new(
-        latitude: Astronoby::Angle.as_degrees(42.37),
-        longitude: Astronoby::Angle.as_degrees(-71.05)
+        latitude: Astronoby::Angle.from_degrees(42.37),
+        longitude: Astronoby::Angle.from_degrees(-71.05)
       )
       sun = described_class.new(epoch: epoch)
 
@@ -570,8 +570,8 @@ RSpec.describe Astronoby::Sun do
       date = Date.new(1991, 3, 14)
       epoch = Astronoby::Epoch.from_time(date)
       observer = Astronoby::Observer.new(
-        latitude: Astronoby::Angle.as_degrees(48.8566),
-        longitude: Astronoby::Angle.as_degrees(2.3522)
+        latitude: Astronoby::Angle.from_degrees(48.8566),
+        longitude: Astronoby::Angle.from_degrees(2.3522)
       )
       sun = described_class.new(epoch: epoch)
 

--- a/spec/astronoby/body_spec.rb
+++ b/spec/astronoby/body_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Astronoby::Body do
     #  Edition: MIT Press
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns the body's rising time" do
-      right_ascension = Astronoby::Angle.as_hms(5, 55, 0)
-      declination = Astronoby::Angle.as_dms(7, 30, 0)
+      right_ascension = Astronoby::Angle.from_hms(5, 55, 0)
+      declination = Astronoby::Angle.from_dms(7, 30, 0)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
         declination: declination
@@ -17,8 +17,8 @@ RSpec.describe Astronoby::Body do
       body = described_class.new(coordinates)
 
       rising_time = body.rising_time(
-        latitude: Astronoby::Angle.as_degrees(38),
-        longitude: Astronoby::Angle.as_degrees(-78),
+        latitude: Astronoby::Angle.from_degrees(38),
+        longitude: Astronoby::Angle.from_degrees(-78),
         date: Date.new(2016, 1, 21),
         apparent: false
       )
@@ -32,8 +32,8 @@ RSpec.describe Astronoby::Body do
     #  Edition: MIT Press
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns nil as the body doesn't rise for the observer" do
-      right_ascension = Astronoby::Angle.as_hms(6, 0, 0)
-      declination = Astronoby::Angle.as_dms(-60, 0, 0)
+      right_ascension = Astronoby::Angle.from_hms(6, 0, 0)
+      declination = Astronoby::Angle.from_dms(-60, 0, 0)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
         declination: declination
@@ -41,8 +41,8 @@ RSpec.describe Astronoby::Body do
       body = described_class.new(coordinates)
 
       rising_time = body.rising_time(
-        latitude: Astronoby::Angle.as_degrees(45),
-        longitude: Astronoby::Angle.as_degrees(-100),
+        latitude: Astronoby::Angle.from_degrees(45),
+        longitude: Astronoby::Angle.from_degrees(-100),
         date: Date.new(2015, 12, 1)
       )
 
@@ -57,16 +57,16 @@ RSpec.describe Astronoby::Body do
     it "returns the body's rising time" do
       offset = -4
       coordinates = Astronoby::Coordinates::Horizontal.new(
-        azimuth: Astronoby::Angle.as_degrees(90),
-        altitude: Astronoby::Angle.as_degrees(45),
-        latitude: Astronoby::Angle.as_degrees(38.25),
-        longitude: Astronoby::Angle.as_degrees(-78.3)
+        azimuth: Astronoby::Angle.from_degrees(90),
+        altitude: Astronoby::Angle.from_degrees(45),
+        latitude: Astronoby::Angle.from_degrees(38.25),
+        longitude: Astronoby::Angle.from_degrees(-78.3)
       ).to_equatorial(time: Time.new(2015, 6, 6, 21, 0, 0, offset))
       body = described_class.new(coordinates)
 
       rising_time = body.rising_time(
-        latitude: Astronoby::Angle.as_degrees(38.25),
-        longitude: Astronoby::Angle.as_degrees(-78.3),
+        latitude: Astronoby::Angle.from_degrees(38.25),
+        longitude: Astronoby::Angle.from_degrees(-78.3),
         date: Date.new(2015, 6, 6),
         apparent: false
       )
@@ -82,14 +82,14 @@ RSpec.describe Astronoby::Body do
     #  Chapter: 33 - Rising and setting
     it "returns the body's rising time" do
       coordinates = Astronoby::Coordinates::Equatorial.new(
-        right_ascension: Astronoby::Angle.as_hms(23, 39, 20),
-        declination: Astronoby::Angle.as_dms(21, 42, 0)
+        right_ascension: Astronoby::Angle.from_hms(23, 39, 20),
+        declination: Astronoby::Angle.from_dms(21, 42, 0)
       )
       body = described_class.new(coordinates)
 
       rising_time = body.rising_time(
-        latitude: Astronoby::Angle.as_degrees(30),
-        longitude: Astronoby::Angle.as_degrees(64),
+        latitude: Astronoby::Angle.from_degrees(30),
+        longitude: Astronoby::Angle.from_degrees(64),
         date: Date.new(2010, 8, 24)
       )
 
@@ -104,8 +104,8 @@ RSpec.describe Astronoby::Body do
     #  Edition: MIT Press
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns the body's rising azimuth" do
-      right_ascension = Astronoby::Angle.as_hms(5, 55, 0)
-      declination = Astronoby::Angle.as_dms(7, 30, 0)
+      right_ascension = Astronoby::Angle.from_hms(5, 55, 0)
+      declination = Astronoby::Angle.from_dms(7, 30, 0)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
         declination: declination
@@ -113,7 +113,7 @@ RSpec.describe Astronoby::Body do
       body = described_class.new(coordinates)
 
       rising_azimuth = body.rising_azimuth(
-        latitude: Astronoby::Angle.as_degrees(38),
+        latitude: Astronoby::Angle.from_degrees(38),
         apparent: false
       )
 
@@ -128,8 +128,8 @@ RSpec.describe Astronoby::Body do
     #  Edition: MIT Press
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns the body's setting time" do
-      right_ascension = Astronoby::Angle.as_hms(5, 55, 0)
-      declination = Astronoby::Angle.as_dms(7, 30, 0)
+      right_ascension = Astronoby::Angle.from_hms(5, 55, 0)
+      declination = Astronoby::Angle.from_dms(7, 30, 0)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
         declination: declination
@@ -137,8 +137,8 @@ RSpec.describe Astronoby::Body do
       body = described_class.new(coordinates)
 
       setting_time = body.setting_time(
-        latitude: Astronoby::Angle.as_degrees(38),
-        longitude: Astronoby::Angle.as_degrees(-78),
+        latitude: Astronoby::Angle.from_degrees(38),
+        longitude: Astronoby::Angle.from_degrees(-78),
         date: Date.new(2016, 1, 21),
         apparent: false
       )
@@ -152,8 +152,8 @@ RSpec.describe Astronoby::Body do
     #  Edition: MIT Press
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns nil as the body doesn't set for the observer" do
-      right_ascension = Astronoby::Angle.as_hms(6, 0, 0)
-      declination = Astronoby::Angle.as_dms(-60, 0, 0)
+      right_ascension = Astronoby::Angle.from_hms(6, 0, 0)
+      declination = Astronoby::Angle.from_dms(-60, 0, 0)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
         declination: declination
@@ -161,8 +161,8 @@ RSpec.describe Astronoby::Body do
       body = described_class.new(coordinates)
 
       setting_time = body.setting_time(
-        latitude: Astronoby::Angle.as_degrees(45),
-        longitude: Astronoby::Angle.as_degrees(-100),
+        latitude: Astronoby::Angle.from_degrees(45),
+        longitude: Astronoby::Angle.from_degrees(-100),
         date: Date.new(2015, 12, 1)
       )
 
@@ -176,16 +176,16 @@ RSpec.describe Astronoby::Body do
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns the body's setting time" do
       coordinates = Astronoby::Coordinates::Horizontal.new(
-        azimuth: Astronoby::Angle.as_degrees(90),
-        altitude: Astronoby::Angle.as_degrees(45),
-        latitude: Astronoby::Angle.as_degrees(38.25),
-        longitude: Astronoby::Angle.as_degrees(-78.3)
+        azimuth: Astronoby::Angle.from_degrees(90),
+        altitude: Astronoby::Angle.from_degrees(45),
+        latitude: Astronoby::Angle.from_degrees(38.25),
+        longitude: Astronoby::Angle.from_degrees(-78.3)
       ).to_equatorial(time: Time.new(2015, 6, 6, 21, 0, 0, "-04:00"))
       body = described_class.new(coordinates)
 
       setting_time = body.setting_time(
-        latitude: Astronoby::Angle.as_degrees(38.25),
-        longitude: Astronoby::Angle.as_degrees(-78.3),
+        latitude: Astronoby::Angle.from_degrees(38.25),
+        longitude: Astronoby::Angle.from_degrees(-78.3),
         date: Date.new(2015, 6, 6),
         apparent: false
       )
@@ -200,14 +200,14 @@ RSpec.describe Astronoby::Body do
     #  Chapter: 33 - Rising and setting
     it "returns the body's rising time" do
       coordinates = Astronoby::Coordinates::Equatorial.new(
-        right_ascension: Astronoby::Angle.as_hms(23, 39, 20),
-        declination: Astronoby::Angle.as_dms(21, 42, 0)
+        right_ascension: Astronoby::Angle.from_hms(23, 39, 20),
+        declination: Astronoby::Angle.from_dms(21, 42, 0)
       )
       body = described_class.new(coordinates)
 
       setting_time = body.setting_time(
-        latitude: Astronoby::Angle.as_degrees(30),
-        longitude: Astronoby::Angle.as_degrees(64),
+        latitude: Astronoby::Angle.from_degrees(30),
+        longitude: Astronoby::Angle.from_degrees(64),
         date: Date.new(2010, 8, 24)
       )
 
@@ -222,8 +222,8 @@ RSpec.describe Astronoby::Body do
     #  Edition: MIT Press
     #  Chapter: 5 - Stars in the Nighttime Sky
     it "returns the body's setting azimuth" do
-      right_ascension = Astronoby::Angle.as_hms(5, 55, 0)
-      declination = Astronoby::Angle.as_dms(7, 30, 0)
+      right_ascension = Astronoby::Angle.from_hms(5, 55, 0)
+      declination = Astronoby::Angle.from_dms(7, 30, 0)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
         declination: declination
@@ -231,7 +231,7 @@ RSpec.describe Astronoby::Body do
       body = described_class.new(coordinates)
 
       setting_azimuth = body.setting_azimuth(
-        latitude: Astronoby::Angle.as_degrees(38),
+        latitude: Astronoby::Angle.from_degrees(38),
         apparent: false
       )
 

--- a/spec/astronoby/coordinates/ecliptic_spec.rb
+++ b/spec/astronoby/coordinates/ecliptic_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Astronoby::Coordinates::Ecliptic do
     #  Chapter: 4 - Orbits and Coordinate Systems, p.95
     context "with real life arguments (book example)" do
       it "computes properly" do
-        latitude = Astronoby::Angle.as_dms(1, 12, 0)
-        longitude = Astronoby::Angle.as_dms(184, 36, 0)
+        latitude = Astronoby::Angle.from_dms(1, 12, 0)
+        longitude = Astronoby::Angle.from_dms(184, 36, 0)
         epoch = Astronoby::Epoch::J2000
 
         equatorial_coordinates = described_class.new(
@@ -37,7 +37,7 @@ RSpec.describe Astronoby::Coordinates::Ecliptic do
     context "with real life arguments (book example)" do
       it "computes properly" do
         latitude = Astronoby::Angle.zero
-        longitude = Astronoby::Angle.as_dms(120, 30, 30)
+        longitude = Astronoby::Angle.from_dms(120, 30, 30)
         epoch = Astronoby::Epoch::J2000
 
         equatorial_coordinates = described_class.new(
@@ -63,8 +63,8 @@ RSpec.describe Astronoby::Coordinates::Ecliptic do
     #  Chapter: 27 - Ecliptic to equatorial coordinate conversion, p.52
     context "with real life arguments (book example)" do
       it "computes properly" do
-        latitude = Astronoby::Angle.as_dms(4, 52, 31)
-        longitude = Astronoby::Angle.as_dms(139, 41, 10)
+        latitude = Astronoby::Angle.from_dms(4, 52, 31)
+        longitude = Astronoby::Angle.from_dms(139, 41, 10)
         epoch = Astronoby::Epoch.from_time(Time.utc(2009, 7, 6, 0, 0, 0))
 
         equatorial_coordinates = described_class.new(

--- a/spec/astronoby/coordinates/equatorial_spec.rb
+++ b/spec/astronoby/coordinates/equatorial_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     #  Edition: Cambridge University Press
     #  Chapter: 24 - Converting between right ascension and hour angle
     it "converts right ascension to hour angle" do
-      longitude = Astronoby::Angle.as_degrees(-64)
+      longitude = Astronoby::Angle.from_degrees(-64)
       time = Time.new(1980, 4, 22, 14, 36, 51.67, "-04:00")
-      right_ascension = Astronoby::Angle.as_hms(18, 32, 21)
+      right_ascension = Astronoby::Angle.from_hms(18, 32, 21)
       declination = Astronoby::Angle.zero
 
       coordinates = described_class.new(
@@ -30,13 +30,13 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
   describe "#to_horizontal" do
     it "returns a new instance of Astronoby::Coordinates::Horizontal" do
       time = Time.new
-      latitude = Astronoby::Angle.as_degrees(50)
+      latitude = Astronoby::Angle.from_degrees(50)
       longitude = Astronoby::Angle.zero
 
       expect(
         described_class.new(
-          right_ascension: Astronoby::Angle.as_dms(23, 59, 59),
-          declination: Astronoby::Angle.as_dms(89, 59, 59)
+          right_ascension: Astronoby::Angle.from_dms(23, 59, 59),
+          declination: Astronoby::Angle.from_dms(89, 59, 59)
         ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
       ).to be_an_instance_of(Astronoby::Coordinates::Horizontal)
     end
@@ -49,12 +49,12 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2016, 1, 21, 21, 30, 0, "-05:00")
-        latitude = Astronoby::Angle.as_degrees(38)
-        longitude = Astronoby::Angle.as_degrees(-78)
+        latitude = Astronoby::Angle.from_degrees(38)
+        longitude = Astronoby::Angle.from_degrees(-78)
 
         horizontal_coordinates = described_class.new(
-          right_ascension: Astronoby::Angle.as_hms(17, 43, 54),
-          declination: Astronoby::Angle.as_dms(-22, 10, 0)
+          right_ascension: Astronoby::Angle.from_hms(17, 43, 54),
+          declination: Astronoby::Angle.from_dms(-22, 10, 0)
         ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
 
         expect(horizontal_coordinates.altitude.str(:dms)).to(
@@ -74,12 +74,12 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2016, 1, 21, 21, 45, 0, "-05:00")
-        latitude = Astronoby::Angle.as_degrees(38)
-        longitude = Astronoby::Angle.as_degrees(-78)
+        latitude = Astronoby::Angle.from_degrees(38)
+        longitude = Astronoby::Angle.from_degrees(-78)
 
         horizontal_coordinates = described_class.new(
-          right_ascension: Astronoby::Angle.as_hms(5, 54, 58),
-          declination: Astronoby::Angle.as_dms(7, 29, 54)
+          right_ascension: Astronoby::Angle.from_hms(5, 54, 58),
+          declination: Astronoby::Angle.from_dms(7, 29, 54)
         ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
 
         expect(horizontal_coordinates.altitude.str(:dms)).to(
@@ -99,12 +99,12 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2015, 12, 1, 9, 0, 0, "-08:00")
-        latitude = Astronoby::Angle.as_degrees(45)
-        longitude = Astronoby::Angle.as_degrees(-100)
+        latitude = Astronoby::Angle.from_degrees(45)
+        longitude = Astronoby::Angle.from_degrees(-100)
 
         horizontal_coordinates = described_class.new(
-          right_ascension: Astronoby::Angle.as_hms(6, 0, 0),
-          declination: Astronoby::Angle.as_degrees(-60)
+          right_ascension: Astronoby::Angle.from_hms(6, 0, 0),
+          declination: Astronoby::Angle.from_degrees(-60)
         ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
 
         expect(horizontal_coordinates.altitude.str(:dms)).to(
@@ -124,13 +124,13 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2015, 12, 1, 9, 0, 0, "-08:00")
-        latitude = Astronoby::Angle.as_degrees(52)
+        latitude = Astronoby::Angle.from_degrees(52)
         longitude = Astronoby::Angle.zero
 
         horizontal_coordinates = described_class.new(
-          declination: Astronoby::Angle.as_dms(23, 13, 10),
+          declination: Astronoby::Angle.from_dms(23, 13, 10),
           right_ascension: nil,
-          hour_angle: Astronoby::Angle.as_hms(5, 51, 44)
+          hour_angle: Astronoby::Angle.from_hms(5, 51, 44)
         ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
 
         expect(horizontal_coordinates.altitude.str(:dms)).to(
@@ -151,8 +151,8 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     #  Chapter: 4 - Orbits and Coordinate Systems
     context "with real life arguments (book example)" do
       it "computes properly" do
-        right_ascension = Astronoby::Angle.as_hms(11, 10, 13)
-        declination = Astronoby::Angle.as_dms(30, 5, 40)
+        right_ascension = Astronoby::Angle.from_hms(11, 10, 13)
+        declination = Astronoby::Angle.from_dms(30, 5, 40)
         epoch = Astronoby::Epoch::J2000
 
         ecliptic_coordinates = described_class.new(
@@ -176,8 +176,8 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     #  Chapter: 13 - Transformation of coordinates
     context "with real life arguments (book example)" do
       it "computes properly" do
-        right_ascension = Astronoby::Angle.as_hms(7, 45, 18.946)
-        declination = Astronoby::Angle.as_dms(28, 1, 34.26)
+        right_ascension = Astronoby::Angle.from_hms(7, 45, 18.946)
+        declination = Astronoby::Angle.from_dms(28, 1, 34.26)
         epoch = Astronoby::Epoch::J2000
 
         ecliptic_coordinates = described_class.new(
@@ -201,8 +201,8 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     #  Chapter: 28 - Equatorial to ecliptic coordinate conversion
     context "with real life arguments (book example)" do
       it "computes properly" do
-        right_ascension = Astronoby::Angle.as_hms(9, 34, 53.32)
-        declination = Astronoby::Angle.as_dms(19, 32, 6.01)
+        right_ascension = Astronoby::Angle.from_hms(9, 34, 53.32)
+        declination = Astronoby::Angle.from_dms(19, 32, 6.01)
         epoch = Astronoby::Epoch.from_time(Time.utc(2009, 7, 6, 0, 0, 0))
 
         ecliptic_coordinates = described_class.new(
@@ -223,8 +223,8 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
   describe "#to_epoch" do
     it "returns a new instance of Astronoby::Coordinates::Equatorial" do
       coordinates = described_class.new(
-        right_ascension: Astronoby::Angle.as_hms(12, 0, 0),
-        declination: Astronoby::Angle.as_degrees(180),
+        right_ascension: Astronoby::Angle.from_hms(12, 0, 0),
+        declination: Astronoby::Angle.from_degrees(180),
         epoch: Astronoby::Epoch::J2000
       )
 

--- a/spec/astronoby/coordinates/horizontal_spec.rb
+++ b/spec/astronoby/coordinates/horizontal_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Astronoby::Coordinates::Horizontal do
     it "returns a new instance of Astronoby::Coordinates::Equatorial" do
       expect(
         described_class.new(
-          azimuth: Astronoby::Angle.as_degrees(100),
-          altitude: Astronoby::Angle.as_degrees(80),
-          latitude: Astronoby::Angle.as_degrees(50),
+          azimuth: Astronoby::Angle.from_degrees(100),
+          altitude: Astronoby::Angle.from_degrees(80),
+          latitude: Astronoby::Angle.from_degrees(50),
           longitude: Astronoby::Angle.zero
         ).to_equatorial(time: Time.new)
       ).to be_a(Astronoby::Coordinates::Equatorial)
@@ -21,10 +21,10 @@ RSpec.describe Astronoby::Coordinates::Horizontal do
     context "with real life arguments (book example)" do
       it "computes properly" do
         equatorial_coordinates = described_class.new(
-          azimuth: Astronoby::Angle.as_dms(171, 5, 0),
-          altitude: Astronoby::Angle.as_dms(59, 13, 0),
-          latitude: Astronoby::Angle.as_degrees(38),
-          longitude: Astronoby::Angle.as_degrees(-78)
+          azimuth: Astronoby::Angle.from_dms(171, 5, 0),
+          altitude: Astronoby::Angle.from_dms(59, 13, 0),
+          latitude: Astronoby::Angle.from_degrees(38),
+          longitude: Astronoby::Angle.from_degrees(-78)
         ).to_equatorial(time: Time.new(2016, 1, 21, 21, 45, 0, "-05:00"))
 
         expect(equatorial_coordinates.right_ascension.str(:hms)).to(
@@ -44,10 +44,10 @@ RSpec.describe Astronoby::Coordinates::Horizontal do
     context "with real life arguments (book example)" do
       it "computes properly" do
         equatorial_coordinates = described_class.new(
-          azimuth: Astronoby::Angle.as_dms(341, 33, 17),
-          altitude: Astronoby::Angle.as_dms(-73, 27, 19),
-          latitude: Astronoby::Angle.as_degrees(38),
-          longitude: Astronoby::Angle.as_degrees(-78)
+          azimuth: Astronoby::Angle.from_dms(341, 33, 17),
+          altitude: Astronoby::Angle.from_dms(-73, 27, 19),
+          latitude: Astronoby::Angle.from_degrees(38),
+          longitude: Astronoby::Angle.from_degrees(-78)
         ).to_equatorial(time: Time.new(2016, 1, 21, 21, 30, 0, "-05:00"))
 
         expect(equatorial_coordinates.right_ascension.str(:hms)).to(
@@ -67,10 +67,10 @@ RSpec.describe Astronoby::Coordinates::Horizontal do
     context "with real life arguments (book example)" do
       it "computes properly" do
         equatorial_coordinates = described_class.new(
-          azimuth: Astronoby::Angle.as_degrees(90),
-          altitude: Astronoby::Angle.as_degrees(45),
-          latitude: Astronoby::Angle.as_degrees(38.25),
-          longitude: Astronoby::Angle.as_degrees(-78.3)
+          azimuth: Astronoby::Angle.from_degrees(90),
+          altitude: Astronoby::Angle.from_degrees(45),
+          latitude: Astronoby::Angle.from_degrees(38.25),
+          longitude: Astronoby::Angle.from_degrees(-78.3)
         ).to_equatorial(time: Time.new(2015, 6, 6, 21, 0, 0, "-04:00"))
 
         expect(equatorial_coordinates.right_ascension.str(:hms)).to(

--- a/spec/astronoby/geocentric_parallax_spec.rb
+++ b/spec/astronoby/geocentric_parallax_spec.rb
@@ -68,13 +68,13 @@ RSpec.describe Astronoby::GeocentricParallax do
     #  Edition: Cambridge University Press
     #  Chapter: 39 - Calculating correction for parallax
     it "returns the corrected equatorial coordinates for the Moon" do
-      latitude = Astronoby::Angle.as_degrees(50)
-      longitude = Astronoby::Angle.as_degrees(-100)
+      latitude = Astronoby::Angle.from_degrees(50)
+      longitude = Astronoby::Angle.from_degrees(-100)
       elevation = 60
       time = Time.utc(1979, 2, 26, 16, 45)
       true_coordinates = Astronoby::Coordinates::Equatorial.new(
-        right_ascension: Astronoby::Angle.as_hms(22, 35, 19),
-        declination: Astronoby::Angle.as_dms(-7, 41, 13)
+        right_ascension: Astronoby::Angle.from_hms(22, 35, 19),
+        declination: Astronoby::Angle.from_dms(-7, 41, 13)
       )
       distance = BigDecimal("56.221228") *
         described_class::EARTH_EQUATORIAL_RADIUS
@@ -100,13 +100,13 @@ RSpec.describe Astronoby::GeocentricParallax do
     #  Edition: Cambridge University Press
     #  Chapter: 39 - Calculating correction for parallax
     it "returns the corrected equatorial coordinates for the Sun" do
-      latitude = Astronoby::Angle.as_degrees(50)
-      longitude = Astronoby::Angle.as_degrees(-100)
+      latitude = Astronoby::Angle.from_degrees(50)
+      longitude = Astronoby::Angle.from_degrees(-100)
       elevation = 60
       time = Time.utc(1979, 2, 26, 16, 45)
       true_coordinates = Astronoby::Coordinates::Equatorial.new(
-        right_ascension: Astronoby::Angle.as_hms(22, 36, 44),
-        declination: Astronoby::Angle.as_dms(-8, 44, 24)
+        right_ascension: Astronoby::Angle.from_hms(22, 36, 44),
+        declination: Astronoby::Angle.from_dms(-8, 44, 24)
       )
       distance = BigDecimal("0.9901") *
         described_class::ASTRONOMICAL_UNIT_IN_METERS

--- a/spec/astronoby/observer_spec.rb
+++ b/spec/astronoby/observer_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe Astronoby::Observer do
   describe "#pressure" do
     it "returns the computed pression in millibars" do
-      latitude = Astronoby::Angle.as_degrees(0)
-      longitude = Astronoby::Angle.as_degrees(0)
+      latitude = Astronoby::Angle.from_degrees(0)
+      longitude = Astronoby::Angle.from_degrees(0)
       elevation = 100
       temperature = 273.15 + 10
 
@@ -20,8 +20,8 @@ RSpec.describe Astronoby::Observer do
 
     context "when elevation and temperature are not provided" do
       it "returns the computed pression in millibars" do
-        latitude = Astronoby::Angle.as_degrees(0)
-        longitude = Astronoby::Angle.as_degrees(0)
+        latitude = Astronoby::Angle.from_degrees(0)
+        longitude = Astronoby::Angle.from_degrees(0)
 
         pressure = described_class
           .new(latitude: latitude, longitude: longitude)

--- a/spec/astronoby/precession_spec.rb
+++ b/spec/astronoby/precession_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Astronoby::Precession do
     #  Edition: Cambridge University Press
     #  Chapter: 34 - Precession
     it "returns equatorial coordinates with the right epoch" do
-      right_ascension = Astronoby::Angle.as_hms(9, 10, 43)
-      declination = Astronoby::Angle.as_dms(14, 23, 25)
+      right_ascension = Astronoby::Angle.from_hms(9, 10, 43)
+      declination = Astronoby::Angle.from_dms(14, 23, 25)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
         declination: declination,
@@ -32,8 +32,8 @@ RSpec.describe Astronoby::Precession do
     #  Edition: Cambridge University Press
     #  Chapter: 34 - Precession
     it "returns the right new equatorial coordinates" do
-      right_ascension = Astronoby::Angle.as_hms(9, 10, 43)
-      declination = Astronoby::Angle.as_dms(14, 23, 25)
+      right_ascension = Astronoby::Angle.from_hms(9, 10, 43)
+      declination = Astronoby::Angle.from_dms(14, 23, 25)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
         declination: declination,
@@ -59,8 +59,8 @@ RSpec.describe Astronoby::Precession do
     #  Edition: MIT Press
     #  Chapter: 4 - Orbits and Coordinate Systems
     it "returns the right new equatorial coordinates" do
-      right_ascension = Astronoby::Angle.as_hms(12, 32, 6)
-      declination = Astronoby::Angle.as_dms(30, 5, 40)
+      right_ascension = Astronoby::Angle.from_hms(12, 32, 6)
+      declination = Astronoby::Angle.from_dms(30, 5, 40)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
         declination: declination,
@@ -86,8 +86,8 @@ RSpec.describe Astronoby::Precession do
     #  Edition: MIT Press
     #  Chapter: 4 - Orbits and Coordinate Systems
     it "returns the right new equatorial coordinates" do
-      right_ascension = Astronoby::Angle.as_hms(12, 34, 34)
-      declination = Astronoby::Angle.as_dms(29, 49, 8)
+      right_ascension = Astronoby::Angle.from_hms(12, 34, 34)
+      declination = Astronoby::Angle.from_dms(29, 49, 8)
       coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: right_ascension,
         declination: declination,

--- a/spec/astronoby/refraction_spec.rb
+++ b/spec/astronoby/refraction_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Astronoby::Refraction do
   describe "::angle" do
     it "returns an Angle" do
       coordinates = Astronoby::Coordinates::Horizontal.new(
-        azimuth: Astronoby::Angle.as_degrees(100),
-        altitude: Astronoby::Angle.as_degrees(80),
-        latitude: Astronoby::Angle.as_degrees(50),
+        azimuth: Astronoby::Angle.from_degrees(100),
+        altitude: Astronoby::Angle.from_degrees(80),
+        latitude: Astronoby::Angle.from_degrees(50),
         longitude: Astronoby::Angle.zero
       )
       observer = instance_double(
@@ -32,11 +32,11 @@ RSpec.describe Astronoby::Refraction do
     # The book example expects a refraction angle of +0° 10′ 11.2464″
     it "computes the refraction angle" do
       time = Time.utc(1987, 3, 23, 1, 1, 24)
-      latitude = Astronoby::Angle.as_degrees(BigDecimal("51.203611"))
-      longitude = Astronoby::Angle.as_degrees(BigDecimal("0.17"))
+      latitude = Astronoby::Angle.from_degrees(BigDecimal("51.203611"))
+      longitude = Astronoby::Angle.from_degrees(BigDecimal("0.17"))
       true_equatorial_coordinates = Astronoby::Coordinates::Equatorial.new(
-        right_ascension: Astronoby::Angle.as_hms(23, 14, 0),
-        declination: Astronoby::Angle.as_dms(40, 10, 0)
+        right_ascension: Astronoby::Angle.from_hms(23, 14, 0),
+        declination: Astronoby::Angle.from_dms(40, 10, 0)
       )
       true_horizontal_coordinates = true_equatorial_coordinates.to_horizontal(
         time: time,
@@ -64,9 +64,9 @@ RSpec.describe Astronoby::Refraction do
     #  Chapter: 37 - Refraction
     it "computes the refraction angle" do
       coordinates = Astronoby::Coordinates::Horizontal.new(
-        azimuth: Astronoby::Angle.as_dms(283, 16, 15.70),
-        altitude: Astronoby::Angle.as_dms(19, 20, 3.64),
-        latitude: Astronoby::Angle.as_degrees(52),
+        azimuth: Astronoby::Angle.from_dms(283, 16, 15.70),
+        altitude: Astronoby::Angle.from_dms(19, 20, 3.64),
+        latitude: Astronoby::Angle.from_degrees(52),
         longitude: Astronoby::Angle.zero
       )
       observer = instance_double(
@@ -87,9 +87,9 @@ RSpec.describe Astronoby::Refraction do
   describe "::correct_horizontal_coordinates" do
     it "returns horizontal coordinates" do
       true_coordinates = Astronoby::Coordinates::Horizontal.new(
-        azimuth: Astronoby::Angle.as_degrees(100),
-        altitude: Astronoby::Angle.as_degrees(80),
-        latitude: Astronoby::Angle.as_degrees(50),
+        azimuth: Astronoby::Angle.from_degrees(100),
+        altitude: Astronoby::Angle.from_degrees(80),
+        latitude: Astronoby::Angle.from_degrees(50),
         longitude: Astronoby::Angle.zero
       )
       observer = instance_double(
@@ -113,9 +113,9 @@ RSpec.describe Astronoby::Refraction do
     #  Chapter: 37 - Refraction
     it "computes accurate apparent coordinates" do
       true_coordinates = Astronoby::Coordinates::Horizontal.new(
-        azimuth: Astronoby::Angle.as_dms(283, 16, 15.70),
-        altitude: Astronoby::Angle.as_dms(19, 20, 3.64),
-        latitude: Astronoby::Angle.as_degrees(52),
+        azimuth: Astronoby::Angle.from_dms(283, 16, 15.70),
+        altitude: Astronoby::Angle.from_dms(19, 20, 3.64),
+        latitude: Astronoby::Angle.from_degrees(52),
         longitude: Astronoby::Angle.zero
       )
       observer = instance_double(

--- a/spec/astronoby/time/local_sidereal_time_spec.rb
+++ b/spec/astronoby/time/local_sidereal_time_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Astronoby::LocalSiderealTime do
         date: date,
         time: 4 + 40 / 60.0 + 5.23 / 3600.0
       )
-      longitude = Astronoby::Angle.as_degrees(-64)
+      longitude = Astronoby::Angle.from_degrees(-64)
 
       lst = described_class.from_gst(gst: gst, longitude: longitude)
 
@@ -35,7 +35,7 @@ RSpec.describe Astronoby::LocalSiderealTime do
         date: date,
         time: 2 + 3 / 60.0 + 41 / 3600.0
       )
-      longitude = Astronoby::Angle.as_degrees(-40)
+      longitude = Astronoby::Angle.from_degrees(-40)
 
       lst = described_class.from_gst(gst: gst, longitude: longitude)
 
@@ -54,7 +54,7 @@ RSpec.describe Astronoby::LocalSiderealTime do
     #  Edition: Cambridge University Press
     #  Chapter: 15 - Converting LST to GST
     it "returns the Greenwich sidereal time for 2024-03-14" do
-      longitude = Astronoby::Angle.as_degrees(-64)
+      longitude = Astronoby::Angle.from_degrees(-64)
       date = Date.new(2024, 3, 14)
       time = 24 / 60.0 + 5.23 / 3600.0
       lst = described_class.new(date: date, time: time, longitude: longitude)
@@ -74,7 +74,7 @@ RSpec.describe Astronoby::LocalSiderealTime do
     #  Edition: MIT Press
     #  Chapter: 3 - Time Conversions
     it "returns the Greenwich sidereal time for 2014-12-13" do
-      longitude = Astronoby::Angle.as_degrees(-77)
+      longitude = Astronoby::Angle.from_degrees(-77)
       date = Date.new(2014, 12, 13)
       time = 1 + 18 / 60.0 + 34 / 3600.0
       lst = described_class.new(date: date, time: time, longitude: longitude)
@@ -94,7 +94,7 @@ RSpec.describe Astronoby::LocalSiderealTime do
     #  Edition: MIT Press
     #  Chapter: 3 - Time Conversions
     it "returns the Greenwich sidereal time for 200-07-05" do
-      longitude = Astronoby::Angle.as_degrees(60)
+      longitude = Astronoby::Angle.from_degrees(60)
       date = Date.new(2000, 7, 5)
       time = 5 + 54 / 60.0 + 20 / 3600.0
       lst = described_class.new(date: date, time: time, longitude: longitude)

--- a/spec/astronoby/util/astrodynamics_spec.rb
+++ b/spec/astronoby/util/astrodynamics_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Astronoby::Util::Astrodynamics do
   describe "::eccentric_anomaly_newton_raphson" do
     it "returns an angle" do
-      mean_anomaly = Astronoby::Angle.as_radians(0.431845)
+      mean_anomaly = Astronoby::Angle.from_radians(0.431845)
       orbital_eccentricity = 0.5
       precision = 2e-06
       iterations = 10
@@ -24,7 +24,7 @@ RSpec.describe Astronoby::Util::Astrodynamics do
     #  Edition: MIT Press
     #  Chapter: 4 - Orbits and Coordinate Systems
     it "computes and returns an approximate solution" do
-      mean_anomaly = Astronoby::Angle.as_radians(0.431845)
+      mean_anomaly = Astronoby::Angle.from_radians(0.431845)
       orbital_eccentricity = 0.5
       precision = 2e-06
       iterations = 10
@@ -45,7 +45,7 @@ RSpec.describe Astronoby::Util::Astrodynamics do
     #  Edition: MIT Press
     #  Chapter: 4 - Orbits and Coordinate Systems
     it "computes and returns an approximate solution" do
-      mean_anomaly = Astronoby::Angle.as_degrees(5.498078)
+      mean_anomaly = Astronoby::Angle.from_degrees(5.498078)
       orbital_eccentricity = 0.00035
       precision = 2e-06
       iterations = 10
@@ -66,7 +66,7 @@ RSpec.describe Astronoby::Util::Astrodynamics do
     #  Edition: MIT Press
     #  Chapter: 4 - Orbits and Coordinate Systems
     it "computes and returns an approximate solution" do
-      mean_anomaly = Astronoby::Angle.as_degrees(5.498078)
+      mean_anomaly = Astronoby::Angle.from_degrees(5.498078)
       orbital_eccentricity = 0.6813025
       precision = 2e-06
       iterations = 10
@@ -87,7 +87,7 @@ RSpec.describe Astronoby::Util::Astrodynamics do
     #  Edition: MIT Press
     #  Chapter: 4 - Orbits and Coordinate Systems
     it "computes and returns an approximate solution" do
-      mean_anomaly = Astronoby::Angle.as_degrees(5.498078)
+      mean_anomaly = Astronoby::Angle.from_degrees(5.498078)
       orbital_eccentricity = 0.85
       precision = 2e-06
       iterations = 10

--- a/spec/astronoby/util/trigonometry_spec.rb
+++ b/spec/astronoby/util/trigonometry_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Astronoby::Util::Trigonometry do
       it "doesn't adjust" do
         initial_angle = Astronoby::Angle.zero
         adjustement = described_class.adjustement_for_arctangent(
-          Astronoby::Angle.as_degrees(1),
-          Astronoby::Angle.as_degrees(1),
+          Astronoby::Angle.from_degrees(1),
+          Astronoby::Angle.from_degrees(1),
           initial_angle
         )
 
@@ -33,8 +33,8 @@ RSpec.describe Astronoby::Util::Trigonometry do
     context "when term1 is positive and term2 is negative" do
       it "adjusts by 180°" do
         adjustement = described_class.adjustement_for_arctangent(
-          Astronoby::Angle.as_degrees(1),
-          Astronoby::Angle.as_degrees(-1),
+          Astronoby::Angle.from_degrees(1),
+          Astronoby::Angle.from_degrees(-1),
           Astronoby::Angle.zero
         )
 
@@ -46,8 +46,8 @@ RSpec.describe Astronoby::Util::Trigonometry do
     context "when term1 is negative and term2 is positive" do
       it "adjusts by 360°" do
         adjustement = described_class.adjustement_for_arctangent(
-          Astronoby::Angle.as_degrees(-1),
-          Astronoby::Angle.as_degrees(1),
+          Astronoby::Angle.from_degrees(-1),
+          Astronoby::Angle.from_degrees(1),
           Astronoby::Angle.zero
         )
 
@@ -59,8 +59,8 @@ RSpec.describe Astronoby::Util::Trigonometry do
     context "when term1 is negative and term2 is negative" do
       it "adjusts by 180°" do
         adjustement = described_class.adjustement_for_arctangent(
-          Astronoby::Angle.as_degrees(-1),
-          Astronoby::Angle.as_degrees(-1),
+          Astronoby::Angle.from_degrees(-1),
+          Astronoby::Angle.from_degrees(-1),
           Astronoby::Angle.zero
         )
 


### PR DESCRIPTION
The initial names `as_radians`, `as_degrees` and `as_hours` were misleading since we made `Angle` a single class for handling all units of angles, always stored in radians.

It use to make sense when we had classes like `Radian`, `Degree` and `Hour`, but now that an angle is always stored in radians, `as_*` could let the reader think that the angle is going to be initialized in the specified unit.

These methods have been renamed into the following:
* `::from_radians`
* `::from_degrees`
* `::from_hours`
* `::from_dms`
* `::from_hms`