### PR TITLE
Drop `BigDecimal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ major one is released.
 
 ```rb
 angle1 = Astronoby::Angle.from_degrees(90)
-angle2 = Astronoby::Angle.from_radians(Astronoby::Angle::PI / 2)
+angle2 = Astronoby::Angle.from_radians(Math::PI / 2)
 angle3 = Astronoby::Angle.from_hours(12)
 
 angle1 == angle2
@@ -83,8 +83,8 @@ horizontal_coordinates = sun.horizontal_coordinates(
   longitude: longitude
 )
 
-horizontal_coordinates.altitude.degrees.to_f
-# => 27.50008242057459
+horizontal_coordinates.altitude.degrees
+# => 27.500082420575094
 
 horizontal_coordinates.altitude.str(:dms)
 # => "+27° 30′ 0.2967″"

--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -1,21 +1,18 @@
 # frozen_string_literal: true
 
-require "bigdecimal/math"
-
 module Astronoby
   class Angle
     include Comparable
 
-    PRECISION = 14
-    PI = BigMath.PI(PRECISION)
-    PI_IN_DEGREES = BigDecimal("180")
+    MIN_PRECISION = 10
+    PI_IN_DEGREES = 180.0
 
-    FULL_CIRCLE_IN_RADIANS = (2 * PI)
+    FULL_CIRCLE_IN_RADIANS = (2 * Math::PI)
 
-    RADIAN_PER_HOUR = PI / BigDecimal("12")
-    MINUTES_PER_DEGREE = BigDecimal("60")
-    MINUTES_PER_HOUR = BigDecimal("60")
-    SECONDS_PER_MINUTE = BigDecimal("60")
+    RADIAN_PER_HOUR = Math::PI / 12.0
+    MINUTES_PER_DEGREE = 60.0
+    MINUTES_PER_HOUR = 60.0
+    SECONDS_PER_MINUTE = 60.0
     SECONDS_PER_HOUR = MINUTES_PER_HOUR * SECONDS_PER_MINUTE
 
     FORMATS = %i[dms hms].freeze
@@ -31,7 +28,7 @@ module Astronoby
       end
 
       def from_degrees(degrees)
-        radians = degrees / PI_IN_DEGREES * PI
+        radians = degrees / PI_IN_DEGREES * Math::PI
         from_radians(radians)
       end
 
@@ -70,16 +67,12 @@ module Astronoby
     attr_reader :radians
 
     def initialize(radians)
-      @radians = if radians.is_a?(Integer) || radians.is_a?(BigDecimal)
-        BigDecimal(radians)
-      else
-        BigDecimal(radians, PRECISION)
-      end
+      @radians = radians
       freeze
     end
 
     def degrees
-      @radians * PI_IN_DEGREES / PI
+      @radians * PI_IN_DEGREES / Math::PI
     end
 
     def hours
@@ -153,7 +146,7 @@ module Astronoby
         absolute_decimal_minutes - absolute_decimal_minutes.floor
       )
 
-      Dms.new(sign, degrees, minutes, seconds.to_f.floor(4))
+      Dms.new(sign, degrees, minutes, seconds.floor(4))
     end
 
     def to_hms(hrs)
@@ -168,7 +161,7 @@ module Astronoby
         absolute_decimal_minutes - absolute_decimal_minutes.floor
       )
 
-      Hms.new(hours, minutes, seconds.to_f.floor(4))
+      Hms.new(hours, minutes, seconds.floor(4))
     end
   end
 end

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -4,7 +4,7 @@ module Astronoby
   class Sun
     SEMI_MAJOR_AXIS_IN_METERS = 149_598_500_000
     ANGULAR_DIAMETER = Angle.from_degrees(0.533128)
-    INTERPOLATION_FACTOR = BigDecimal("24.07")
+    INTERPOLATION_FACTOR = 24.07
 
     # Source:
     #  Title: Practical Astronomy with your Calculator or Spreadsheet

--- a/lib/astronoby/coordinates/equatorial.rb
+++ b/lib/astronoby/coordinates/equatorial.rb
@@ -39,7 +39,7 @@ module Astronoby
         azimuth = Angle.acos(t2)
 
         if ha.sin.positive?
-          azimuth = Angle.from_degrees(BigDecimal("360") - azimuth.degrees)
+          azimuth = Angle.from_degrees(360 - azimuth.degrees)
         end
 
         Horizontal.new(

--- a/lib/astronoby/coordinates/horizontal.rb
+++ b/lib/astronoby/coordinates/horizontal.rb
@@ -31,7 +31,7 @@ module Astronoby
 
         if @azimuth.sin.positive?
           hour_angle_degrees = Angle
-            .from_degrees(BigDecimal("360") - hour_angle_degrees)
+            .from_degrees(360 - hour_angle_degrees)
             .degrees
         end
 

--- a/lib/astronoby/geocentric_parallax.rb
+++ b/lib/astronoby/geocentric_parallax.rb
@@ -9,8 +9,8 @@ module Astronoby
     #  Chapter: 39 - Calculating correction for parallax
 
     ASTRONOMICAL_UNIT_IN_METERS = 149_597_870_700
-    EARTH_FLATTENING_CORRECTION = BigDecimal("0.996647")
-    EARTH_EQUATORIAL_RADIUS = BigDecimal("6378140")
+    EARTH_FLATTENING_CORRECTION = 0.996647
+    EARTH_EQUATORIAL_RADIUS = 6378140.0
 
     # Equatorial horizontal parallax
     # @param distance [Numeric] Distance of the body from the center of the

--- a/lib/astronoby/observer.rb
+++ b/lib/astronoby/observer.rb
@@ -3,12 +3,12 @@
 module Astronoby
   class Observer
     DEFAULT_ELEVATION = 0
-    DEFAULT_TEMPERATURE = BigDecimal("283.15")
-    PRESSURE_AT_SEA_LEVEL = BigDecimal("1013.25")
-    PASCAL_PER_MILLIBAR = BigDecimal("0.01")
-    EARTH_GRAVITATIONAL_ACCELERATION = BigDecimal("9.80665")
-    MOLAR_MASS_OF_AIR = BigDecimal("0.0289644")
-    UNIVERSAL_GAS_CONSTANT = BigDecimal("8.31432")
+    DEFAULT_TEMPERATURE = 283.15
+    PRESSURE_AT_SEA_LEVEL = 1013.25
+    PASCAL_PER_MILLIBAR = 0.01
+    EARTH_GRAVITATIONAL_ACCELERATION = 9.80665
+    MOLAR_MASS_OF_AIR = 0.0289644
+    UNIVERSAL_GAS_CONSTANT = 8.31432
 
     attr_reader :latitude, :longitude, :elevation, :temperature
 
@@ -37,7 +37,7 @@ module Astronoby
     # Compute an estimation of the atmospheric pressure based on the elevation
     # and temperature
     #
-    # @return [BigDecimal] the atmospheric pressure in millibars.
+    # @return [Float] the atmospheric pressure in millibars.
     def pressure
       @pressure ||= PRESSURE_AT_SEA_LEVEL * pressure_ratio
     end

--- a/lib/astronoby/time/greenwich_sidereal_time.rb
+++ b/lib/astronoby/time/greenwich_sidereal_time.rb
@@ -3,9 +3,9 @@
 module Astronoby
   class GreenwichSiderealTime
     JULIAN_CENTURIES_EXPONENTS = [
-      BigDecimal("6.697374558"),
-      BigDecimal("2400.051336"),
-      BigDecimal("0.000025862")
+      6.697374558,
+      2400.051336,
+      0.000025862
     ].freeze
 
     attr_reader :date, :time
@@ -29,7 +29,7 @@ module Astronoby
         utc.min / 60.0 +
         (utc.sec + utc.subsec) / 3600.0
 
-      gmst = BigDecimal("1.002737909") * ut_in_hours + t0
+      gmst = 1.002737909 * ut_in_hours + t0
       gmst += 24 if gmst.negative?
       gmst -= 24 if gmst > 24
 
@@ -61,7 +61,7 @@ module Astronoby
       a += 24 if a.negative?
       a -= 24 if a > 24
 
-      utc = BigDecimal("0.9972695663") * a
+      utc = 0.9972695663 * a
 
       decimal_hour_to_time(date, utc)
     end

--- a/lib/astronoby/util/trigonometry.rb
+++ b/lib/astronoby/util/trigonometry.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bigdecimal/math"
-
 module Astronoby
   module Util
     module Trigonometry

--- a/spec/astronoby/angle_spec.rb
+++ b/spec/astronoby/angle_spec.rb
@@ -18,22 +18,19 @@ RSpec.describe Astronoby::Angle do
 
   describe "::from_radians" do
     it "returns an Angle object" do
-      expect(described_class.from_radians(described_class::PI))
-        .to be_a(described_class)
+      expect(described_class.from_radians(Math::PI)).to be_a(described_class)
     end
 
     it "normalizes the angle" do
-      expect(described_class.from_radians(2 * described_class::PI).radians)
-        .to eq 0
+      expect(described_class.from_radians(2 * Math::PI).radians).to eq 0
 
-      expect(described_class.from_radians(3 * described_class::PI).radians)
-        .to eq described_class::PI
+      expect(described_class.from_radians(3 * Math::PI).radians).to eq Math::PI
 
-      expect(described_class.from_radians(-5 * described_class::PI).radians)
-        .to eq(-described_class::PI)
+      expect(described_class.from_radians(-5 * Math::PI).radians)
+        .to eq(-Math::PI)
 
-      expect(described_class.from_radians(described_class::PI / 2).radians)
-        .to eq described_class::PI / 2
+      expect(described_class.from_radians(Math::PI / 2).radians)
+        .to eq Math::PI / 2
     end
   end
 
@@ -72,11 +69,11 @@ RSpec.describe Astronoby::Angle do
 
     it "initializes an angle with the inverse sine of a ratio" do
       ratio = 0.5
-      angle = described_class.asin(ratio)
-      precision = 10**-described_class::PRECISION
-      radians = described_class::PI / 6
+      precision = 10**-described_class::MIN_PRECISION
 
-      expect(angle.radians).to be_within(precision).of(radians)
+      angle = described_class.asin(ratio)
+
+      expect(angle.radians).to be_within(precision).of(Math::PI / 6)
     end
   end
 
@@ -87,11 +84,11 @@ RSpec.describe Astronoby::Angle do
 
     it "initializes an angle with the inverse sine of a ratio" do
       ratio = 0.5
-      angle = described_class.acos(ratio)
-      precision = 10**-described_class::PRECISION
-      radians = described_class::PI / 3
+      precision = 10**-described_class::MIN_PRECISION
 
-      expect(angle.radians).to be_within(precision).of(radians)
+      angle = described_class.acos(ratio)
+
+      expect(angle.radians).to be_within(precision).of(Math::PI / 3)
     end
   end
 
@@ -102,35 +99,34 @@ RSpec.describe Astronoby::Angle do
 
     it "initializes an angle with the inverse sine of a ratio" do
       ratio = 1
-      angle = described_class.atan(ratio)
-      precision = 10**-described_class::PRECISION
-      radians = described_class::PI / 4
+      precision = 10**-described_class::MIN_PRECISION
 
-      expect(angle.radians).to be_within(precision).of(radians)
+      angle = described_class.atan(ratio)
+
+      expect(angle.radians).to be_within(precision).of(Math::PI / 4)
     end
   end
 
   describe "#radians" do
     it "returns the angle value in radian unit" do
-      radians = described_class.new(described_class::PI).radians
+      radians = described_class.new(Math::PI).radians
 
-      expect(radians).to eq described_class::PI
+      expect(radians).to eq Math::PI
     end
 
     context "when the angle is initialized from degrees" do
       it "returns the angle value in radian unit" do
         radians = described_class.from_degrees(180).radians
 
-        expect(radians).to eq described_class::PI
+        expect(radians).to eq Math::PI
       end
     end
 
     context "when the angle is initialized from hours" do
-      it "returns the angle value in radian unit within fixed precision" do
+      it "returns the angle value in radian unit" do
         radians = described_class.from_hours(12).radians
 
-        expect(radians)
-          .to be_within(10**-described_class::PRECISION).of(described_class::PI)
+        expect(radians).to eq Math::PI
       end
     end
   end
@@ -144,48 +140,48 @@ RSpec.describe Astronoby::Angle do
 
     context "when the angle is initialized from radians" do
       it "returns the angle value in degree unit" do
-        degrees = described_class.from_radians(described_class::PI).degrees
+        degrees = described_class.from_radians(Math::PI).degrees
 
         expect(degrees).to eq 180
       end
     end
 
     context "when the angle is initialized from hours" do
-      it "returns the angle value in degree unit within fixed precision" do
+      it "returns the angle value in degree unit" do
         degrees = described_class.from_hours(12).degrees
 
-        expect(degrees).to be_within(10**-described_class::PRECISION).of(180)
+        expect(degrees).to eq 180
       end
     end
   end
 
   describe "#hours" do
-    it "returns the angle value in degree unit within fixed precision" do
+    it "returns the angle value in degree unit" do
       hours = described_class.from_hours(12).hours
 
       expect(hours).to eq 12
     end
 
     context "when the angle is initialized from radians" do
-      it "returns the angle value in degree unit within fixed precision" do
-        hours = described_class.from_radians(described_class::PI).hours
+      it "returns the angle value in degree unit" do
+        hours = described_class.from_radians(Math::PI).hours
 
-        expect(hours).to be_within(10**-described_class::PRECISION).of(12)
+        expect(hours).to eq 12
       end
     end
 
     context "when the angle is initialized from degrees" do
-      it "returns the angle value in degree unit within fixed precision" do
+      it "returns the angle value in degree unit" do
         hours = described_class.from_degrees(180).hours
 
-        expect(hours).to be_within(10**-described_class::PRECISION).of(12)
+        expect(hours).to eq 12
       end
     end
   end
 
   describe "#+" do
     it "returns a new angle with a value of the two angles added" do
-      angle_1 = described_class.from_radians(described_class::PI)
+      angle_1 = described_class.from_radians(Math::PI)
       angle_2 = described_class.from_degrees(45)
 
       new_angle = angle_1 + angle_2
@@ -196,7 +192,7 @@ RSpec.describe Astronoby::Angle do
 
   describe "#-" do
     it "returns a new angle with a value of the two angles substracted" do
-      angle_1 = described_class.from_radians(described_class::PI)
+      angle_1 = described_class.from_radians(Math::PI)
       angle_2 = described_class.from_degrees(45)
 
       new_angle = angle_1 - angle_2
@@ -207,10 +203,10 @@ RSpec.describe Astronoby::Angle do
 
   describe "#sin" do
     it "returns the sine value of the angle" do
-      radians = described_class::PI / 6
+      radians = Math::PI / 6
       angle = described_class.from_radians(radians)
 
-      sine = angle.sin.ceil(described_class::PRECISION)
+      sine = angle.sin.round(described_class::MIN_PRECISION)
 
       expect(sine).to eq 0.5
     end
@@ -218,10 +214,10 @@ RSpec.describe Astronoby::Angle do
 
   describe "#cos" do
     it "returns the cosine value of the angle" do
-      radians = described_class::PI / 3
+      radians = Math::PI / 3
       angle = described_class.from_radians(radians)
 
-      cosine = angle.cos.ceil(described_class::PRECISION)
+      cosine = angle.cos.round(described_class::MIN_PRECISION)
 
       expect(cosine).to eq 0.5
     end
@@ -229,10 +225,10 @@ RSpec.describe Astronoby::Angle do
 
   describe "#tan" do
     it "returns the tangent value of the angle" do
-      radians = described_class::PI / 4
+      radians = Math::PI / 4
       angle = described_class.from_radians(radians)
 
-      tangent = angle.tan.ceil(described_class::PRECISION)
+      tangent = angle.tan.round(described_class::MIN_PRECISION)
 
       expect(tangent).to eq 1
     end
@@ -318,10 +314,10 @@ RSpec.describe Astronoby::Angle do
     it "handles comparison of angles" do
       angle = described_class.from_degrees(10)
       same_angle = described_class.from_degrees(10)
-      greater_angle = described_class.from_radians(described_class::PI)
+      greater_angle = described_class.from_radians(Math::PI)
       smaller_angle = described_class.from_degrees(5)
       way_greater_angle = described_class.from_degrees(365)
-      negative_angle = described_class.from_radians(-described_class::PI)
+      negative_angle = described_class.from_radians(-Math::PI)
 
       expect(angle == same_angle).to be true
       expect(angle != same_angle).to be false
@@ -370,7 +366,7 @@ RSpec.describe Astronoby::Angle do
         it "properly formats the angle" do
           angle = described_class.from_degrees(10.2958)
 
-          expect(angle.str(:dms)).to eq "+10° 17′ 44.88″"
+          expect(angle.str(:dms)).to eq "+10° 17′ 44.8799″"
         end
       end
 
@@ -387,7 +383,7 @@ RSpec.describe Astronoby::Angle do
       it "properly formats the angle" do
         angle = described_class.from_hours(12.345678)
 
-        expect(angle.str(:hms)).to eq "12h 20m 44.4408s"
+        expect(angle.str(:hms)).to eq "12h 20m 44.4407s"
       end
     end
 

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -23,9 +23,7 @@ RSpec.describe Astronoby::Sun do
         .new(epoch: epoch)
         .true_ecliptic_coordinates
 
-      expect(ecliptic_coordinates.longitude.degrees.to_f).to(
-        eq(316.5726713406949)
-      )
+      expect(ecliptic_coordinates.longitude.degrees).to eq 316.5726713406949
       # Result from the book: 316.562255
     end
 
@@ -43,9 +41,7 @@ RSpec.describe Astronoby::Sun do
         .new(epoch: epoch)
         .true_ecliptic_coordinates
 
-      expect(ecliptic_coordinates.longitude.degrees.to_f).to(
-        eq(137.36484079770798)
-      )
+      expect(ecliptic_coordinates.longitude.degrees).to eq 137.36484079770804
       # Result from the book: 137.386004
     end
 
@@ -62,9 +58,7 @@ RSpec.describe Astronoby::Sun do
         .new(epoch: epoch)
         .true_ecliptic_coordinates
 
-      expect(ecliptic_coordinates.longitude.degrees.to_f).to(
-        eq(45.92185191445673)
-      )
+      expect(ecliptic_coordinates.longitude.degrees).to eq 45.921851914456795
       # Result from the book: 45.917857
     end
 

--- a/spec/astronoby/geocentric_parallax_spec.rb
+++ b/spec/astronoby/geocentric_parallax_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Astronoby::GeocentricParallax do
     #  Edition: Cambridge University Press
     #  Chapter: 39 - Calculating correction for parallax
     it "returns the equatorial horizontal parallax for the Moon" do
-      distance = BigDecimal("56.2212278") *
-        described_class::EARTH_EQUATORIAL_RADIUS
+      distance = 56.2212278 * described_class::EARTH_EQUATORIAL_RADIUS
 
       angle = described_class.angle(distance: distance)
 
@@ -29,8 +28,7 @@ RSpec.describe Astronoby::GeocentricParallax do
     #  Edition: Cambridge University Press
     #  Chapter: 39 - Calculating correction for parallax
     it "returns the equatorial horizontal parallax for the Sun" do
-      distance = BigDecimal("0.9901") *
-        described_class::ASTRONOMICAL_UNIT_IN_METERS
+      distance = 0.9901 * described_class::ASTRONOMICAL_UNIT_IN_METERS
 
       angle = described_class.angle(distance: distance)
 
@@ -76,8 +74,7 @@ RSpec.describe Astronoby::GeocentricParallax do
         right_ascension: Astronoby::Angle.from_hms(22, 35, 19),
         declination: Astronoby::Angle.from_dms(-7, 41, 13)
       )
-      distance = BigDecimal("56.221228") *
-        described_class::EARTH_EQUATORIAL_RADIUS
+      distance = 56.221228 * described_class::EARTH_EQUATORIAL_RADIUS
 
       apparent_coordinates = described_class.for_equatorial_coordinates(
         latitude: latitude,
@@ -108,8 +105,7 @@ RSpec.describe Astronoby::GeocentricParallax do
         right_ascension: Astronoby::Angle.from_hms(22, 36, 44),
         declination: Astronoby::Angle.from_dms(-8, 44, 24)
       )
-      distance = BigDecimal("0.9901") *
-        described_class::ASTRONOMICAL_UNIT_IN_METERS
+      distance = 0.9901 * described_class::ASTRONOMICAL_UNIT_IN_METERS
 
       apparent_coordinates = described_class.for_equatorial_coordinates(
         latitude: latitude,

--- a/spec/astronoby/mean_obliquity_spec.rb
+++ b/spec/astronoby/mean_obliquity_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe Astronoby::MeanObliquity do
     it "returns the obliquity angle for standard epoch" do
       obliquity = described_class.for_epoch(Astronoby::Epoch::J2000)
 
-      expect(obliquity.degrees.to_f).to eq(23.439291666666666)
+      expect(obliquity.degrees).to eq(23.439291666666666)
     end
 
     it "returns the obliquity angle for epoch 1950" do
       obliquity = described_class.for_epoch(Astronoby::Epoch::J1950)
 
-      expect(obliquity.degrees.to_f).to eq 23.445793854513887
+      expect(obliquity.degrees).to eq 23.445793854513887
     end
 
     # Source:

--- a/spec/astronoby/refraction_spec.rb
+++ b/spec/astronoby/refraction_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Astronoby::Refraction do
     # The book example expects a refraction angle of +0° 10′ 11.2464″
     it "computes the refraction angle" do
       time = Time.utc(1987, 3, 23, 1, 1, 24)
-      latitude = Astronoby::Angle.from_degrees(BigDecimal("51.203611"))
-      longitude = Astronoby::Angle.from_degrees(BigDecimal("0.17"))
+      latitude = Astronoby::Angle.from_degrees(51.203611)
+      longitude = Astronoby::Angle.from_degrees(0.17)
       true_equatorial_coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: Astronoby::Angle.from_hms(23, 14, 0),
         declination: Astronoby::Angle.from_dms(40, 10, 0)

--- a/spec/astronoby/util/trigonometry_spec.rb
+++ b/spec/astronoby/util/trigonometry_spec.rb
@@ -38,8 +38,7 @@ RSpec.describe Astronoby::Util::Trigonometry do
           Astronoby::Angle.zero
         )
 
-        expect(adjustement.radians)
-          .to be_within(Astronoby::Angle::PRECISION).of(Math::PI)
+        expect(adjustement.radians).to eq Math::PI
       end
     end
 
@@ -48,11 +47,10 @@ RSpec.describe Astronoby::Util::Trigonometry do
         adjustement = described_class.adjustement_for_arctangent(
           Astronoby::Angle.from_degrees(-1),
           Astronoby::Angle.from_degrees(1),
-          Astronoby::Angle.zero
+          Astronoby::Angle.from_degrees(-90)
         )
 
-        expect(adjustement.radians)
-          .to be_within(Astronoby::Angle::PRECISION).of(Math::PI * 2)
+        expect(adjustement.degrees).to eq 270
       end
     end
 
@@ -64,8 +62,7 @@ RSpec.describe Astronoby::Util::Trigonometry do
           Astronoby::Angle.zero
         )
 
-        expect(adjustement.radians)
-          .to be_within(Astronoby::Angle::PRECISION).of(Math::PI)
+        expect(adjustement.radians).to eq Math::PI
       end
     end
   end


### PR DESCRIPTION
`BigDecimal` was introduced early in the project from my belief that high accuracy was needed.

It turns out that the number of digits in floats are enough to keep a precision up to 0.0001 arcseconds in most calculations.

Using `BigDecimal` has a cost over the overall performance of the library. If it is not absolutely necessary for the calculations, it's better not to use it. Calculations are performed 11 times faster using only floats, for the same precision (see benchmark below).

### Benchmark

The benchmark simply executes usual calculations enabled by the library at the moment, many times.

```rb
Benchmark.bmbm do |x|
  x.report do
    10_000.times do
      time = Time.utc(2023, 2, 17, 11, 0, 0)
      epoch = Astronoby::Epoch.from_time(time)

      observer = Astronoby::Observer.new(
        latitude: Astronoby::Angle.from_degrees(38),
        longitude: Astronoby::Angle.from_degrees(-78)
      )

      sun = Astronoby::Sun.new(epoch: epoch)

      sun
        .apparent_ecliptic_coordinates
        .to_apparent_equatorial(epoch: epoch)
        .to_horizontal(
          time: time,
          latitude: observer.latitude,
          longitude: observer.longitude
        )

      sun.rising_time(observer: observer)
      sun.rising_azimuth(observer: observer).str(:dms)
      sun.setting_time(observer: observer)
      sun.setting_azimuth(observer: observer).str(:dms)

      year = 2024
      Astronoby::EquinoxSolstice.march_equinox(year)
      Astronoby::EquinoxSolstice.june_solstice(year)
    end
  end
end
```

```
                         user    system      total         real
with BigDecimal     61.342663  0.351669  61.694332  (61.892873)
without BigDecimal   5.286487  0.004743   5.291230   (5.308093)
```
