### PR TITLE
Add twilight times

### DIFF
--- a/lib/astronoby/time/greenwich_sidereal_time.rb
+++ b/lib/astronoby/time/greenwich_sidereal_time.rb
@@ -8,6 +8,8 @@ module Astronoby
       0.000025862
     ].freeze
 
+    SIDEREAL_MINUTE_IN_UT_MINUTE = 0.9972695663
+
     attr_reader :date, :time
 
     # Source:
@@ -61,7 +63,7 @@ module Astronoby
       a += 24 if a.negative?
       a -= 24 if a > 24
 
-      utc = 0.9972695663 * a
+      utc = SIDEREAL_MINUTE_IN_UT_MINUTE * a
 
       Util::Time.decimal_hour_to_time(date, utc)
     end

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -665,7 +665,7 @@ RSpec.describe Astronoby::Sun do
       )
 
       expect(sun.morning_civil_twilight_time(observer: observer))
-        .to eq Time.utc(1979, 9, 7, 4, 40, 9)
+        .to eq Time.utc(1979, 9, 7, 4, 44, 23)
       # Time from IMCCE: 04:46
     end
   end
@@ -692,7 +692,7 @@ RSpec.describe Astronoby::Sun do
       )
 
       expect(sun.evening_civil_twilight_time(observer: observer))
-        .to eq Time.utc(1979, 9, 7, 19, 15, 7)
+        .to eq Time.utc(1979, 9, 7, 19, 8, 22)
       # Time from IMCCE: 19:10
     end
   end
@@ -719,7 +719,7 @@ RSpec.describe Astronoby::Sun do
       )
 
       expect(sun.morning_nautical_twilight_time(observer: observer))
-        .to eq Time.utc(1979, 9, 7, 3, 57, 57)
+        .to eq Time.utc(1979, 9, 7, 4, 2, 11)
       # Time from IMCCE: 04:03
     end
   end
@@ -746,7 +746,7 @@ RSpec.describe Astronoby::Sun do
       )
 
       expect(sun.evening_nautical_twilight_time(observer: observer))
-        .to eq Time.utc(1979, 9, 7, 19, 57, 19)
+        .to eq Time.utc(1979, 9, 7, 19, 50, 34)
       # Time from IMCCE: 19:52
     end
   end
@@ -778,7 +778,7 @@ RSpec.describe Astronoby::Sun do
       )
 
       expect(sun.morning_astronomical_twilight_time(observer: observer))
-        .to eq Time.utc(1979, 9, 7, 3, 11, 58)
+        .to eq Time.utc(1979, 9, 7, 3, 16, 13)
       # Time from Practical Astronomy: 03:12
       # Time from IMCCE: 03:17
     end
@@ -825,7 +825,7 @@ RSpec.describe Astronoby::Sun do
       )
 
       expect(sun.evening_astronomical_twilight_time(observer: observer))
-        .to eq Time.utc(1979, 9, 7, 20, 43, 18)
+        .to eq Time.utc(1979, 9, 7, 20, 36, 33)
       # Time from Practical Astronomy: 20:43
       # Time from IMCCE: 20:37
     end

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -643,6 +643,208 @@ RSpec.describe Astronoby::Sun do
     end
   end
 
+  describe "#morning_civil_twilight_time" do
+    it "returns a time" do
+      epoch = Astronoby::Epoch.from_time(Time.new)
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.zero,
+        longitude: Astronoby::Angle.zero
+      )
+
+      expect(sun.morning_civil_twilight_time(observer: observer))
+        .to be_a Time
+    end
+
+    it "returns when the morning civil twilight starts" do
+      epoch = Astronoby::Epoch.from_time(Time.utc(1979, 9, 7))
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_degrees(52),
+        longitude: Astronoby::Angle.zero
+      )
+
+      expect(sun.morning_civil_twilight_time(observer: observer))
+        .to eq Time.utc(1979, 9, 7, 4, 40, 9)
+      # Time from IMCCE: 04:46
+    end
+  end
+
+  describe "#evening_civil_twilight_time" do
+    it "returns a time" do
+      epoch = Astronoby::Epoch.from_time(Time.new)
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.zero,
+        longitude: Astronoby::Angle.zero
+      )
+
+      expect(sun.evening_civil_twilight_time(observer: observer))
+        .to be_a Time
+    end
+
+    it "returns when the evening civil twilight ends" do
+      epoch = Astronoby::Epoch.from_time(Time.utc(1979, 9, 7))
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_degrees(52),
+        longitude: Astronoby::Angle.zero
+      )
+
+      expect(sun.evening_civil_twilight_time(observer: observer))
+        .to eq Time.utc(1979, 9, 7, 19, 15, 7)
+      # Time from IMCCE: 19:10
+    end
+  end
+
+  describe "#morning_nautical_twilight_time" do
+    it "returns a time" do
+      epoch = Astronoby::Epoch.from_time(Time.new)
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.zero,
+        longitude: Astronoby::Angle.zero
+      )
+
+      expect(sun.morning_nautical_twilight_time(observer: observer))
+        .to be_a Time
+    end
+
+    it "returns when the morning nautical twilight starts" do
+      epoch = Astronoby::Epoch.from_time(Time.utc(1979, 9, 7))
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_degrees(52),
+        longitude: Astronoby::Angle.zero
+      )
+
+      expect(sun.morning_nautical_twilight_time(observer: observer))
+        .to eq Time.utc(1979, 9, 7, 3, 57, 57)
+      # Time from IMCCE: 04:03
+    end
+  end
+
+  describe "#evening_nautical_twilight_time" do
+    it "returns a time" do
+      epoch = Astronoby::Epoch.from_time(Time.new)
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.zero,
+        longitude: Astronoby::Angle.zero
+      )
+
+      expect(sun.evening_nautical_twilight_time(observer: observer))
+        .to be_a Time
+    end
+
+    it "returns when the evening nautical twilight ends" do
+      epoch = Astronoby::Epoch.from_time(Time.utc(1979, 9, 7))
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_degrees(52),
+        longitude: Astronoby::Angle.zero
+      )
+
+      expect(sun.evening_nautical_twilight_time(observer: observer))
+        .to eq Time.utc(1979, 9, 7, 19, 57, 19)
+      # Time from IMCCE: 19:52
+    end
+  end
+
+  describe "#morning_astronomical_twilight_time" do
+    it "returns a time" do
+      epoch = Astronoby::Epoch.from_time(Time.new)
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.zero,
+        longitude: Astronoby::Angle.zero
+      )
+
+      expect(sun.morning_astronomical_twilight_time(observer: observer))
+        .to be_a Time
+    end
+
+    # Source:
+    #  Title: Practical Astronomy with your Calculator or Spreadsheet
+    #  Authors: Peter Duffett-Smith and Jonathan Zwart
+    #  Edition: Cambridge University Press
+    #  Chapter: 50 - Twilight, p.114
+    it "returns when the morning astronomical twilight starts" do
+      epoch = Astronoby::Epoch.from_time(Time.utc(1979, 9, 7))
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_degrees(52),
+        longitude: Astronoby::Angle.zero
+      )
+
+      expect(sun.morning_astronomical_twilight_time(observer: observer))
+        .to eq Time.utc(1979, 9, 7, 3, 11, 58)
+      # Time from Practical Astronomy: 03:12
+      # Time from IMCCE: 03:17
+    end
+
+    context "when the twilight never ends" do
+      it "returns nil" do
+        epoch = Astronoby::Epoch.from_time(Time.utc(2024, 6, 20))
+        sun = described_class.new(epoch: epoch)
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(65),
+          longitude: Astronoby::Angle.zero
+        )
+
+        expect(sun.morning_astronomical_twilight_time(observer: observer))
+          .to be_nil
+      end
+    end
+  end
+
+  describe "#evening_astronomical_twilight_time" do
+    it "returns a time" do
+      epoch = Astronoby::Epoch.from_time(Time.new)
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.zero,
+        longitude: Astronoby::Angle.zero
+      )
+
+      expect(sun.evening_astronomical_twilight_time(observer: observer))
+        .to be_a Time
+    end
+
+    # Source:
+    #  Title: Practical Astronomy with your Calculator or Spreadsheet
+    #  Authors: Peter Duffett-Smith and Jonathan Zwart
+    #  Edition: Cambridge University Press
+    #  Chapter: 50 - Twilight, p.114
+    it "returns when the evening astronomical twilight ends" do
+      epoch = Astronoby::Epoch.from_time(Time.utc(1979, 9, 7))
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_degrees(52),
+        longitude: Astronoby::Angle.zero
+      )
+
+      expect(sun.evening_astronomical_twilight_time(observer: observer))
+        .to eq Time.utc(1979, 9, 7, 20, 43, 18)
+      # Time from Practical Astronomy: 20:43
+      # Time from IMCCE: 20:37
+    end
+
+    context "when the twilight never ends" do
+      it "returns nil" do
+        epoch = Astronoby::Epoch.from_time(Time.utc(2024, 6, 20))
+        sun = described_class.new(epoch: epoch)
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(65),
+          longitude: Astronoby::Angle.zero
+        )
+
+        expect(sun.evening_astronomical_twilight_time(observer: observer))
+          .to be_nil
+      end
+    end
+  end
+
   describe "::equation_of_time" do
     it "returns an Integer" do
       date = Date.new

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -668,6 +668,19 @@ RSpec.describe Astronoby::Sun do
         .to eq Time.utc(1979, 9, 7, 4, 44, 23)
       # Time from IMCCE: 04:46
     end
+
+    it "returns when the morning civil twilight starts" do
+      epoch = Astronoby::Epoch.from_time(Time.utc(2024, 3, 14))
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_dms(-33, 52, 4),
+        longitude: Astronoby::Angle.from_dms(151, 12, 26)
+      )
+
+      expect(sun.morning_civil_twilight_time(observer: observer))
+        .to eq Time.utc(2024, 3, 14, 19, 25, 38)
+      # Time from IMCCE: 19:29:29
+    end
   end
 
   describe "#evening_civil_twilight_time" do
@@ -694,6 +707,19 @@ RSpec.describe Astronoby::Sun do
       expect(sun.evening_civil_twilight_time(observer: observer))
         .to eq Time.utc(1979, 9, 7, 19, 8, 22)
       # Time from IMCCE: 19:10
+    end
+
+    it "returns when the evening civil twilight ends" do
+      epoch = Astronoby::Epoch.from_time(Time.utc(2024, 3, 14))
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_dms(-33, 52, 4),
+        longitude: Astronoby::Angle.from_dms(151, 12, 26)
+      )
+
+      expect(sun.evening_civil_twilight_time(observer: observer))
+        .to eq Time.utc(2024, 3, 14, 8, 38, 28)
+      # Time from IMCCE: 08:39:23
     end
   end
 
@@ -722,6 +748,19 @@ RSpec.describe Astronoby::Sun do
         .to eq Time.utc(1979, 9, 7, 4, 2, 11)
       # Time from IMCCE: 04:03
     end
+
+    it "returns when the morning nautical twilight starts" do
+      epoch = Astronoby::Epoch.from_time(Time.utc(2024, 3, 14))
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_dms(-33, 52, 4),
+        longitude: Astronoby::Angle.from_dms(151, 12, 26)
+      )
+
+      expect(sun.morning_nautical_twilight_time(observer: observer))
+        .to eq Time.utc(2024, 3, 14, 18, 56, 26)
+      # Time from IMCCE: 19:00:13
+    end
   end
 
   describe "#evening_nautical_twilight_time" do
@@ -748,6 +787,19 @@ RSpec.describe Astronoby::Sun do
       expect(sun.evening_nautical_twilight_time(observer: observer))
         .to eq Time.utc(1979, 9, 7, 19, 50, 34)
       # Time from IMCCE: 19:52
+    end
+
+    it "returns when the evening nautical twilight ends" do
+      epoch = Astronoby::Epoch.from_time(Time.utc(2024, 3, 14))
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_dms(-33, 52, 4),
+        longitude: Astronoby::Angle.from_dms(151, 12, 26)
+      )
+
+      expect(sun.evening_nautical_twilight_time(observer: observer))
+        .to eq Time.utc(2024, 3, 14, 9, 7, 39)
+      # Time from IMCCE: 09:08:37
     end
   end
 
@@ -781,6 +833,19 @@ RSpec.describe Astronoby::Sun do
         .to eq Time.utc(1979, 9, 7, 3, 16, 13)
       # Time from Practical Astronomy: 03:12
       # Time from IMCCE: 03:17
+    end
+
+    it "returns when the morning astronomical twilight starts" do
+      epoch = Astronoby::Epoch.from_time(Time.utc(2024, 3, 14))
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_dms(-33, 52, 4),
+        longitude: Astronoby::Angle.from_dms(151, 12, 26)
+      )
+
+      expect(sun.morning_astronomical_twilight_time(observer: observer))
+        .to eq Time.utc(2024, 3, 14, 18, 26, 47)
+      # Time from IMCCE: 18:30:31
     end
 
     context "when the twilight never ends" do
@@ -828,6 +893,19 @@ RSpec.describe Astronoby::Sun do
         .to eq Time.utc(1979, 9, 7, 20, 36, 33)
       # Time from Practical Astronomy: 20:43
       # Time from IMCCE: 20:37
+    end
+
+    it "returns when the evening astronomical twilight ends" do
+      epoch = Astronoby::Epoch.from_time(Time.utc(2024, 3, 14))
+      sun = described_class.new(epoch: epoch)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_dms(-33, 52, 4),
+        longitude: Astronoby::Angle.from_dms(151, 12, 26)
+      )
+
+      expect(sun.evening_astronomical_twilight_time(observer: observer))
+        .to eq Time.utc(2024, 3, 14, 9, 37, 18)
+      # Time from IMCCE: 09:38:17
     end
 
     context "when the twilight never ends" do


### PR DESCRIPTION
Due to the atmospheric refraction, the sky remains bright for some time before the sunset and after the sunrise. This brightness of the sky is called twilight and decreases proportionally to the Sun's angular distance below the observer's horizon.

Between the day and the night, three different twilights are defined:
* Civil twilight: when the Sun's between 0° and 6° below the horizon
* Nautical twilight: when the Sun's between 6° and 12° below the horizon
* Astronomical twilight: when the Sun's between 12° and 18° below the horizon

<img src="https://github.com/rhannequin/astronoby/assets/1019025/afd1a20a-ca8a-44b0-9445-9ec410c683f2" width="500" alt="Illustration of the different angles of twilights">

<small>_Source: @timeanddate.com_</small>

This change introduces 6 new methods to `Astronoby::Sun` to provide the instant in time (UTC) of each of these twilight changes:
* `#morning_civil_twilight_time`: when the morning civil twilight starts
* `#evening_civil_twilight_time`: when the evening civil twilight ends
* `#morning_nautical_twilight_time`: when the morning nautical twilight starts
* `#evening_nautical_twilight_time`: when the evening nautical twilight ends
* `#morning_astronomical_twilight_time`: when the night ends and the morning astronomical twilight starts
* `#evening_astronomical_twilight_time`: when the evening astronomical twilight ends and the night starts