### PR TITLE
Add `Angle#-@`

### DIFF
--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -87,6 +87,10 @@ module Astronoby
       self.class.from_radians(@radians - other.radians)
     end
 
+    def -@
+      self.class.from_radians(-@radians)
+    end
+
     def sin
       Math.sin(radians)
     end

--- a/spec/astronoby/angle_spec.rb
+++ b/spec/astronoby/angle_spec.rb
@@ -203,6 +203,16 @@ RSpec.describe Astronoby::Angle do
     end
   end
 
+  describe "#-@" do
+    it "returns a new angle with a value of the opposite of the angle" do
+      angle = described_class.from_degrees(45)
+
+      new_angle = -angle
+
+      expect(new_angle.degrees).to eq(-45)
+    end
+  end
+
   describe "#sin" do
     it "returns the sine value of the angle" do
       radians = Math::PI / 6


### PR DESCRIPTION
This enables the opposite form of an angle.

```rb
angle = Astronoby::Angle.from_degrees(90)
negative_angle = -angle

negative_angle == Astronoby::Angle.from_degrees(-90)
# => true
```