### PR TITLE
Improve accuracy of equation of time

### DIFF
--- a/lib/astronoby/constants.rb
+++ b/lib/astronoby/constants.rb
@@ -3,6 +3,7 @@
 module Astronoby
   class Constants
     DAYS_PER_JULIAN_CENTURY = 36525.0
+    DAYS_PER_JULIAN_MILLENIA = DAYS_PER_JULIAN_CENTURY * 10
 
     HOURS_PER_DAY = 24.0
     DEGREES_PER_CIRCLE = 360.0
@@ -18,5 +19,7 @@ module Astronoby
     RADIAN_PER_HOUR = Math::PI / 12.0
 
     PI_IN_DEGREES = 180.0
+
+    EQUATION_OF_TIME_CONSTANT = 0.0057183
   end
 end

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -681,7 +681,7 @@ RSpec.describe Astronoby::Sun do
     it "returns an Integer" do
       date = Date.new
 
-      equation_of_time = described_class.equation_of_time(date: date)
+      equation_of_time = described_class.equation_of_time(date_or_time: date)
 
       expect(equation_of_time).to be_an Integer
     end
@@ -694,7 +694,7 @@ RSpec.describe Astronoby::Sun do
     it "returns the right value of 2010-07-27" do
       date = Date.new(2010, 7, 27)
 
-      equation_of_time = described_class.equation_of_time(date: date)
+      equation_of_time = described_class.equation_of_time(date_or_time: date)
 
       expect(equation_of_time).to eq(-391)
       # Value from Practical Astronomy: 392
@@ -708,7 +708,7 @@ RSpec.describe Astronoby::Sun do
     it "returns the right value of 2016-05-05" do
       date = Date.new(2016, 5, 5)
 
-      equation_of_time = described_class.equation_of_time(date: date)
+      equation_of_time = described_class.equation_of_time(date_or_time: date)
 
       expect(equation_of_time).to eq(200)
       # Value from Celestial Calculations: 199
@@ -722,9 +722,9 @@ RSpec.describe Astronoby::Sun do
     it "returns the right value of 2015-08-09" do
       date = Date.new(2015, 8, 9)
 
-      equation_of_time = described_class.equation_of_time(date: date)
+      equation_of_time = described_class.equation_of_time(date_or_time: date)
 
-      expect(equation_of_time).to eq(-332)
+      expect(equation_of_time).to eq(-333)
       # Value from Celestial Calculations: 337
     end
 
@@ -736,9 +736,9 @@ RSpec.describe Astronoby::Sun do
     it "returns the right value of 2010-05-06" do
       date = Date.new(2010, 5, 6)
 
-      equation_of_time = described_class.equation_of_time(date: date)
+      equation_of_time = described_class.equation_of_time(date_or_time: date)
 
-      expect(equation_of_time).to eq(201)
+      expect(equation_of_time).to eq(203)
       # Value from Celestial Calculations: 201
     end
 
@@ -750,10 +750,24 @@ RSpec.describe Astronoby::Sun do
     it "returns the right value of 2020-01-01" do
       date = Date.new(2020, 1, 1)
 
-      equation_of_time = described_class.equation_of_time(date: date)
+      equation_of_time = described_class.equation_of_time(date_or_time: date)
 
-      expect(equation_of_time).to eq(-198)
+      expect(equation_of_time).to eq(-199)
       # Value from Celestial Calculations: 187
+    end
+
+    # Source:
+    #  Title: Astronomical Algorithms
+    #  Author: Jean Meeus
+    #  Edition: 2nd edition
+    #  Chapter: 28 - Equation of Time, p.184
+    it "returns the right value of 1992-10-13" do
+      time = Time.new(1992, 10, 13, 0, 0, 0)
+
+      equation_of_time = described_class.equation_of_time(date_or_time: time)
+
+      expect(equation_of_time).to eq(822)
+      # Value from Astronomical Algorithms: 13m 42s=822s
     end
   end
 end


### PR DESCRIPTION
This new algorithm, based on _Astronomical Algorithms_ by Jean Meeus, provide a more accurate algorithm for the equation of time than the previous one. It also supports giving a precise time, or a date.

If a date is provided, the instant of time selected is 12PM UTC of the date, which mostly explains the difference with official results, that are often based only on a date (and an unknown instant of the day).

The result is still in seconds, rounded to the closest integer.

```rb
time = Time.new(1992, 10, 13, 0, 0, 0)

Astronoby::Sun.equation_of_time(date_or_time: time)
# => 822
```