### PR TITLE
Change `Astronoby::Sun` constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,19 +104,19 @@ observation_events.rising_time
 # => 2015-02-05 12:12:59 UTC
 
 observation_events.rising_azimuth.str(:dms)
-# => "+109° 46′ 42.044″"
+# => "+109° 46′ 43.145″"
 
 observation_events.transit_time
 # => 2015-02-05 17:25:59 UTC
 
 observation_events.transit_altitude.str(:dms)
-# => "+36° 8′ 16.6162″"
+# => "+36° 8′ 15.7638″"
 
 observation_events.setting_time
 # => 2015-02-05 22:39:27 UTC
 
 observation_events.setting_azimuth.str(:dms)
-# => "+250° 23′ 34.7233″"
+# => "+250° 23′ 33.614″"
 ```
 
 ### Twilight times

--- a/README.md
+++ b/README.md
@@ -71,12 +71,11 @@ horizontal.azimuth.str(:dms)
 
 ```rb
 time = Time.utc(2023, 2, 17, 11, 0, 0)
-epoch = Astronoby::Epoch.from_time(time)
 
 latitude = Astronoby::Angle.from_degrees(48.8566)
 longitude = Astronoby::Angle.from_degrees(2.3522)
 
-sun = Astronoby::Sun.new(epoch: epoch)
+sun = Astronoby::Sun.new(time: time)
 
 horizontal_coordinates = sun.horizontal_coordinates(
   latitude: latitude,
@@ -84,48 +83,47 @@ horizontal_coordinates = sun.horizontal_coordinates(
 )
 
 horizontal_coordinates.altitude.degrees
-# => 27.500082420575094
+# => 27.500082409271247
 
 horizontal_coordinates.altitude.str(:dms)
-# => "+27° 30′ 0.2967″"
+# => "+27° 30′ 0.2966″"
 ```
 
 ### Sunrise and sunset times and azimuths
 
 ```rb
-date = Date.new(2015, 2, 5)
-epoch = Astronoby::Epoch.from_time(date)
+time = Time.new(2015, 2, 5)
 observer = Astronoby::Observer.new(
   latitude: Astronoby::Angle.from_degrees(38),
   longitude: Astronoby::Angle.from_degrees(-78)
 )
-sun = Astronoby::Sun.new(epoch: epoch)
+sun = Astronoby::Sun.new(time: time)
 observation_events = sun.observation_events(observer: observer)
 
 observation_events.rising_time
 # => 2015-02-05 12:12:59 UTC
 
 observation_events.rising_azimuth.str(:dms)
-# => "+109° 46′ 43.1427″"
+# => "+109° 46′ 42.044″"
 
 observation_events.transit_time
 # => 2015-02-05 17:25:59 UTC
 
 observation_events.transit_altitude.str(:dms)
-# => "+36° 8′ 15.7669″"
+# => "+36° 8′ 16.6162″"
 
 observation_events.setting_time
 # => 2015-02-05 22:39:27 UTC
 
 observation_events.setting_azimuth.str(:dms)
-# => "+250° 23′ 33.6177″"
+# => "+250° 23′ 34.7233″"
 ```
 
 ### Twilight times
 
 ```rb
-epoch = Astronoby::Epoch.from_time(Date.new(2024, 1, 1))
-sun = Astronoby::Sun.new(epoch: epoch)
+time = Time.new(2024, 1, 1)
+sun = Astronoby::Sun.new(time: time)
 observer = Astronoby::Observer.new(
   latitude: Astronoby::Angle.from_degrees(48.8566),
   longitude: Astronoby::Angle.from_degrees(2.3522)
@@ -133,22 +131,22 @@ observer = Astronoby::Observer.new(
 twilight_events = sun.twilight_events(observer: observer)
 
 twilight_events.morning_astronomical_twilight_time
-# => 2024-01-01 05:47:24 UTC
+# => 2024-01-01 05:47:14 UTC
 
 twilight_events.morning_nautical_twilight_time
-# => 2024-01-01 06:25:41 UTC
+# => 2024-01-01 06:25:31 UTC
 
 twilight_events.morning_civil_twilight_time
-# => 2024-01-01 07:05:51 UTC
+# => 2024-01-01 07:05:41 UTC
 
 twilight_events.evening_civil_twilight_time
-# => 2024-01-01 16:37:37 UTC
+# => 2024-01-01 16:37:24 UTC
 
 twilight_events.evening_nautical_twilight_time
-# => 2024-01-01 17:17:46 UTC
+# => 2024-01-01 17:17:34 UTC
 
 twilight_events.evening_astronomical_twilight_time
-# => 2024-01-01 17:56:03 UTC
+# => 2024-01-01 17:55:51 UTC
 ```
 
 ### Solstice and Equinox times

--- a/lib/astronoby/aberration.rb
+++ b/lib/astronoby/aberration.rb
@@ -39,7 +39,7 @@ module Astronoby
 
     def sun_longitude
       @_sun_longitude ||= Sun
-        .new(epoch: @epoch)
+        .new(time: Epoch.to_utc(@epoch))
         .true_ecliptic_coordinates
         .longitude
     end

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -114,22 +114,29 @@ module Astronoby
     # @return [Astronoby::Events::ObservationEvents] Sun's observation events
     def observation_events(observer:)
       today = @time.to_date
+      leap_seconds = Util::Time.terrestrial_universal_time_delta(today)
       yesterday = today.prev_day
-      yesterday_epoch = Epoch.from_time(yesterday)
-      today_epoch = Epoch.from_time(today)
+      yesterday_midnight_terrestrial_time =
+        Time.utc(yesterday.year, yesterday.month, yesterday.day) - leap_seconds
+      yesterday_epoch = Epoch.from_time(yesterday_midnight_terrestrial_time)
+      today_midnight_terrestrial_time =
+        Time.utc(today.year, today.month, today.day) - leap_seconds
+      today_epoch = Epoch.from_time(today_midnight_terrestrial_time)
       tomorrow = today.next_day
-      tomorrow_epoch = Epoch.from_time(tomorrow)
+      tomorrow_midnight_terrestrial_time =
+        Time.utc(tomorrow.year, tomorrow.month, tomorrow.day) - leap_seconds
+      tomorrow_epoch = Epoch.from_time(tomorrow_midnight_terrestrial_time)
 
       coordinates_of_the_previous_day = self.class
-        .new(time: yesterday)
+        .new(time: yesterday_midnight_terrestrial_time)
         .apparent_ecliptic_coordinates
         .to_apparent_equatorial(epoch: yesterday_epoch)
       coordinates_of_the_day = self.class
-        .new(time: today)
+        .new(time: today_midnight_terrestrial_time)
         .apparent_ecliptic_coordinates
         .to_apparent_equatorial(epoch: today_epoch)
       coordinates_of_the_next_day = self.class
-        .new(time: tomorrow)
+        .new(time: tomorrow_midnight_terrestrial_time)
         .apparent_ecliptic_coordinates
         .to_apparent_equatorial(epoch: tomorrow_epoch)
 

--- a/lib/astronoby/equinox_solstice.rb
+++ b/lib/astronoby/equinox_solstice.rb
@@ -130,7 +130,8 @@ module Astronoby
     end
 
     def correction(epoch)
-      sun = Sun.new(epoch: epoch)
+      time = Epoch.to_utc(epoch)
+      sun = Sun.new(time: time)
       longitude = sun.apparent_ecliptic_coordinates.longitude
 
       58 * Angle.from_degrees(@event * 90 - longitude.degrees).sin

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -3,9 +3,9 @@
 RSpec.describe Astronoby::Sun do
   describe "#true_ecliptic_coordinates" do
     it "returns ecliptic coordinates" do
-      epoch = Astronoby::Epoch::DEFAULT_EPOCH
+      time = Time.new
 
-      coordinates = described_class.new(epoch: epoch).true_ecliptic_coordinates
+      coordinates = described_class.new(time: time).true_ecliptic_coordinates
 
       expect(coordinates).to be_a(Astronoby::Coordinates::Ecliptic)
     end
@@ -17,10 +17,9 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 6 - The Sun, p136
     it "computes the coordinates for 2015-02-05" do
       time = Time.new(2015, 2, 5, 12, 0, 0, "-05:00")
-      epoch = Astronoby::Epoch.from_time(time)
 
       ecliptic_coordinates = described_class
-        .new(epoch: epoch)
+        .new(time: time)
         .true_ecliptic_coordinates
 
       expect(ecliptic_coordinates.longitude.degrees).to eq 316.5726713406949
@@ -35,10 +34,9 @@ RSpec.describe Astronoby::Sun do
     #
     it "computes the coordinates for 2000-08-09" do
       time = Time.new(2000, 8, 9, 12, 0, 0, "-04:00")
-      epoch = Astronoby::Epoch.from_time(time)
 
       ecliptic_coordinates = described_class
-        .new(epoch: epoch)
+        .new(time: time)
         .true_ecliptic_coordinates
 
       expect(ecliptic_coordinates.longitude.degrees).to eq 137.36484079770804
@@ -52,10 +50,9 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 6 - The Sun, p149
     it "computes the coordinates for 2015-05-06" do
       time = Time.new(2015, 5, 6, 14, 30, 0, "-04:00")
-      epoch = Astronoby::Epoch.from_time(time)
 
       ecliptic_coordinates = described_class
-        .new(epoch: epoch)
+        .new(time: time)
         .true_ecliptic_coordinates
 
       expect(ecliptic_coordinates.longitude.degrees).to eq 45.921851914456795
@@ -72,7 +69,7 @@ RSpec.describe Astronoby::Sun do
       epoch = Astronoby::Epoch.from_time(time)
 
       ecliptic_coordinates = described_class
-        .new(epoch: epoch)
+        .new(time: time)
         .true_ecliptic_coordinates
       equatorial_coordinates = ecliptic_coordinates
         .to_true_equatorial(epoch: epoch)
@@ -90,10 +87,10 @@ RSpec.describe Astronoby::Sun do
 
   describe "#horizontal_coordinates" do
     it "returns horizontal coordinates" do
-      epoch = Astronoby::Epoch::DEFAULT_EPOCH
+      time = Time.new
 
       coordinates = described_class
-        .new(epoch: epoch)
+        .new(time: time)
         .horizontal_coordinates(
           latitude: Astronoby::Angle.from_degrees(-20),
           longitude: Astronoby::Angle.from_degrees(-30)
@@ -109,8 +106,7 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 6 - The Sun, p.137
     it "computes the horizontal coordinates for the epoch" do
       time = Time.new(2015, 2, 5, 12, 0, 0, "-05:00")
-      epoch = Astronoby::Epoch.from_time(time)
-      sun = described_class.new(epoch: epoch)
+      sun = described_class.new(time: time)
 
       horizontal_coordinates = sun.horizontal_coordinates(
         latitude: Astronoby::Angle.from_degrees(38),
@@ -122,7 +118,7 @@ RSpec.describe Astronoby::Sun do
         # Result from the book: 35° 47′ 0.1″
       )
       expect(horizontal_coordinates.azimuth.str(:dms)).to(
-        eq("+172° 17′ 22.7259″")
+        eq("+172° 17′ 22.7257″")
         # Result from the book: 172° 17′ 46″
       )
     end
@@ -134,8 +130,7 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 6 - The Sun, p.149
     it "computes the coordinates for a given epoch" do
       time = Time.new(2000, 8, 9, 12, 0, 0, "-05:00")
-      epoch = Astronoby::Epoch.from_time(time)
-      sun = described_class.new(epoch: epoch)
+      sun = described_class.new(time: time)
 
       horizontal_coordinates = sun.horizontal_coordinates(
         latitude: Astronoby::Angle.from_degrees(30),
@@ -143,11 +138,11 @@ RSpec.describe Astronoby::Sun do
       )
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
-        eq("+65° 42′ 21.6059″")
+        eq("+65° 42′ 21.6058″")
         # Result from the book: 65° 43′
       )
       expect(horizontal_coordinates.azimuth.str(:dms)).to(
-        eq("+121° 33′ 22.4259″")
+        eq("+121° 33′ 22.4256″")
         # Result from the book: 121° 34′
       )
     end
@@ -159,8 +154,7 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 6 - The Sun, p.149
     it "computes the coordinates for a given epoch" do
       time = Time.new(2015, 5, 6, 14, 30, 0, "-04:00")
-      epoch = Astronoby::Epoch.from_time(time)
-      sun = described_class.new(epoch: epoch)
+      sun = described_class.new(time: time)
 
       horizontal_coordinates = sun.horizontal_coordinates(
         latitude: Astronoby::Angle.from_degrees(-20),
@@ -168,7 +162,7 @@ RSpec.describe Astronoby::Sun do
       )
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
-        eq("+13° 34′ 7.6911″")
+        eq("+13° 34′ 7.6913″")
         # Result from the book: 13° 34′
       )
       expect(horizontal_coordinates.azimuth.str(:dms)).to(
@@ -180,8 +174,9 @@ RSpec.describe Astronoby::Sun do
 
   describe "#earth_distance" do
     it "returns a number in meters" do
-      epoch = Astronoby::Epoch::DEFAULT_EPOCH
-      sun = described_class.new(epoch: epoch)
+      time = Time.new
+
+      sun = described_class.new(time: time)
 
       expect(sun.earth_distance).to be_a Numeric
     end
@@ -193,8 +188,8 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 48 - Calculating the Sun's distance and angular size, p.110
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(1988, 7, 27)
-      epoch = Astronoby::Epoch.from_time(time)
-      sun = described_class.new(epoch: epoch)
+
+      sun = described_class.new(time: time)
 
       expect(sun.earth_distance.round).to eq 151_920_130_151
       # Result from the book: 1.519189×10^8 km
@@ -207,8 +202,8 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 6 - The Sun, p.147
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(2015, 2, 15)
-      epoch = Astronoby::Epoch.from_time(time)
-      sun = described_class.new(epoch: epoch)
+
+      sun = described_class.new(time: time)
 
       expect(sun.earth_distance.round).to eq 147_745_409_916
       # Result from the book: 1.478×10^8 km
@@ -221,8 +216,8 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 6 - The Sun, p.150
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(2015, 8, 9)
-      epoch = Astronoby::Epoch.from_time(time)
-      sun = described_class.new(epoch: epoch)
+
+      sun = described_class.new(time: time)
 
       expect(sun.earth_distance.round).to eq 151_683_526_945
       # Result from the book: 1.517×10^8 km
@@ -235,8 +230,8 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 6 - The Sun, p.150
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(2010, 5, 6)
-      epoch = Astronoby::Epoch.from_time(time)
-      sun = described_class.new(epoch: epoch)
+
+      sun = described_class.new(time: time)
 
       expect(sun.earth_distance.round).to eq 150_902_254_024
       # Result from the book: 1.509×10^8 km
@@ -245,8 +240,9 @@ RSpec.describe Astronoby::Sun do
 
   describe "#angular_size" do
     it "returns an Angle" do
-      epoch = Astronoby::Epoch::DEFAULT_EPOCH
-      sun = described_class.new(epoch: epoch)
+      time = Time.new
+
+      sun = described_class.new(time: time)
 
       expect(sun.angular_size).to be_a Astronoby::Angle
     end
@@ -258,8 +254,8 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 48 - Calculating the Sun's distance and angular size, p.110
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(1988, 7, 27)
-      epoch = Astronoby::Epoch.from_time(time)
-      sun = described_class.new(epoch: epoch)
+
+      sun = described_class.new(time: time)
 
       expect(sun.angular_size.str(:dms)).to eq "+0° 31′ 29.9308″"
       # Result from the book: 0° 31′ 30″
@@ -272,8 +268,8 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 6 - The Sun, p.147
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(2015, 2, 15)
-      epoch = Astronoby::Epoch.from_time(time)
-      sun = described_class.new(epoch: epoch)
+
+      sun = described_class.new(time: time)
 
       expect(sun.angular_size.str(:dms)).to eq "+0° 32′ 23.333″"
       # Result from the book: 0° 32′″
@@ -286,8 +282,8 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 6 - The Sun, p.150
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(2015, 8, 9)
-      epoch = Astronoby::Epoch.from_time(time)
-      sun = described_class.new(epoch: epoch)
+
+      sun = described_class.new(time: time)
 
       expect(sun.angular_size.str(:dms)).to eq "+0° 31′ 32.8788″"
       # Result from the book: 0° 32′″
@@ -300,8 +296,8 @@ RSpec.describe Astronoby::Sun do
     #  Chapter: 6 - The Sun, p.150
     it "computes and return the Earth-Sun distance for a given epoch" do
       time = Time.utc(2010, 5, 6)
-      epoch = Astronoby::Epoch.from_time(time)
-      sun = described_class.new(epoch: epoch)
+
+      sun = described_class.new(time: time)
 
       expect(sun.angular_size.str(:dms)).to eq "+0° 31′ 42.6789″"
       # Result from the book: 0° 32′″
@@ -316,13 +312,12 @@ RSpec.describe Astronoby::Sun do
       #  Edition: MIT Press
       #  Chapter: 6 - The Sun, p.139
       it "returns the sunrise time on 2015-02-05" do
-        date = Date.new(2015, 2, 5)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(2015, 2, 5)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(38),
           longitude: Astronoby::Angle.from_degrees(-78)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         rising_time = observation_events.rising_time
@@ -339,13 +334,12 @@ RSpec.describe Astronoby::Sun do
       #  Edition: Cambridge University Press
       #  Chapter: 49 - Sunrise and sunset, p.112
       it "returns the sunrise time on 1986-03-10" do
-        date = Date.new(1986, 3, 10)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(1986, 3, 10)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(42.37),
           longitude: Astronoby::Angle.from_degrees(-71.05)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         rising_time = observation_events.rising_time
@@ -356,19 +350,35 @@ RSpec.describe Astronoby::Sun do
       end
 
       it "returns the sunrise time on 1991-03-14" do
-        date = Date.new(1991, 3, 14)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(1991, 3, 14)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(48.8566),
           longitude: Astronoby::Angle.from_degrees(2.3522)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         rising_time = observation_events.rising_time
 
         expect(rising_time).to eq Time.utc(1991, 3, 14, 6, 7, 23)
         # Time from IMCCE: 1991-03-14T06:08:45
+      end
+
+      context "when the given time includes a time zone far from the Greenwich meridian" do
+        it "returns the sunrise time for the right date" do
+          time = Time.new(1991, 3, 14, 0, 0, 0, "-10:00")
+          observer = Astronoby::Observer.new(
+            latitude: Astronoby::Angle.from_degrees(-17.6509),
+            longitude: Astronoby::Angle.from_degrees(-149.4260)
+          )
+          sun = described_class.new(time: time)
+          observation_events = sun.observation_events(observer: observer)
+
+          rising_time = observation_events.rising_time
+
+          expect(rising_time).to eq Time.utc(1991, 3, 14, 16, 0, 16)
+          # Time from IMCCE: 1991-03-14T16:01:12
+        end
       end
     end
 
@@ -379,13 +389,12 @@ RSpec.describe Astronoby::Sun do
       #  Edition: MIT Press
       #  Chapter: 6 - The Sun, p.139
       it "returns the Sun's transit time on 2015-02-05" do
-        date = Date.new(2015, 2, 5)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(2015, 2, 5)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(38),
           longitude: Astronoby::Angle.from_degrees(-78)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         transit_time = observation_events.transit_time
@@ -401,13 +410,12 @@ RSpec.describe Astronoby::Sun do
       #  Edition: Cambridge University Press
       #  Chapter: 49 - Sunrise and sunset, p.112
       it "returns the Sun's transit time on 1986-03-10" do
-        date = Date.new(1986, 3, 10)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(1986, 3, 10)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(42.37),
           longitude: Astronoby::Angle.from_degrees(-71.05)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         transit_time = observation_events.transit_time
@@ -417,13 +425,12 @@ RSpec.describe Astronoby::Sun do
       end
 
       it "returns the Sun's transit time on 1991-03-14" do
-        date = Date.new(1991, 3, 14)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(1991, 3, 14)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(48.8566),
           longitude: Astronoby::Angle.from_degrees(2.3522)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         transit_time = observation_events.transit_time
@@ -440,13 +447,12 @@ RSpec.describe Astronoby::Sun do
       #  Edition: MIT Press
       #  Chapter: 6 - The Sun, p.139
       it "returns the sunset time on 2015-02-05" do
-        date = Date.new(2015, 2, 5)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(2015, 2, 5)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(38),
           longitude: Astronoby::Angle.from_degrees(-78)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         setting_time = observation_events.setting_time
@@ -463,13 +469,12 @@ RSpec.describe Astronoby::Sun do
       #  Edition: Cambridge University Press
       #  Chapter: 49 - Sunrise and sunset, p.112
       it "returns the sunset time on 1986-03-10" do
-        date = Date.new(1986, 3, 10)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(1986, 3, 10)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(42.37),
           longitude: Astronoby::Angle.from_degrees(-71.05)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         setting_time = observation_events.setting_time
@@ -480,19 +485,35 @@ RSpec.describe Astronoby::Sun do
       end
 
       it "returns the sunset time on 1991-03-14" do
-        date = Date.new(1991, 3, 14)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(1991, 3, 14)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(48.8566),
           longitude: Astronoby::Angle.from_degrees(2.3522)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         setting_time = observation_events.setting_time
 
         expect(setting_time).to eq Time.utc(1991, 3, 14, 17, 53, 26)
         # Time from IMCCE: 1991-03-14T17:52:00
+      end
+    end
+
+    context "when the given time includes a time zone far from the Greenwich meridian" do
+      it "returns the sunset time for the right date" do
+        time = Time.new(1991, 3, 14, 6, 0, 0, "+12:00")
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(-36.8509),
+          longitude: Astronoby::Angle.from_degrees(174.7645)
+        )
+        sun = described_class.new(time: time)
+        observation_events = sun.observation_events(observer: observer)
+
+        setting_time = observation_events.setting_time
+
+        expect(setting_time).to eq Time.utc(1991, 3, 14, 6, 42, 40)
+        # Time from IMCCE: 1991-03-14T06:41:30
       end
     end
   end
@@ -505,13 +526,12 @@ RSpec.describe Astronoby::Sun do
       #  Edition: MIT Press
       #  Chapter: 6 - The Sun, p.139
       it "returns the sunrise azimuth on 2015-02-05" do
-        date = Date.new(2015, 2, 5)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(2015, 2, 5)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(38),
           longitude: Astronoby::Angle.from_degrees(-78)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         rising_azimuth = observation_events.rising_azimuth
@@ -522,13 +542,12 @@ RSpec.describe Astronoby::Sun do
       end
 
       it "returns the sunrise azimuth on 1986-03-10" do
-        date = Date.new(1986, 3, 10)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(1986, 3, 10)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(42.37),
           longitude: Astronoby::Angle.from_degrees(-71.05)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         rising_azimuth = observation_events.rising_azimuth
@@ -538,13 +557,12 @@ RSpec.describe Astronoby::Sun do
       end
 
       it "returns the sunrise azimuth on 1991-03-14" do
-        date = Date.new(1991, 3, 14)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(1991, 3, 14)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(48.8566),
           longitude: Astronoby::Angle.from_degrees(2.3522)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         rising_azimuth = observation_events.rising_azimuth
@@ -561,13 +579,12 @@ RSpec.describe Astronoby::Sun do
       #  Edition: MIT Press
       #  Chapter: 6 - The Sun, p.139
       it "returns the sunset azimuth on 2015-02-05" do
-        date = Date.new(2015, 2, 5)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(2015, 2, 5)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(38),
           longitude: Astronoby::Angle.from_degrees(-78)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         setting_azimuth = observation_events.setting_azimuth
@@ -578,13 +595,12 @@ RSpec.describe Astronoby::Sun do
       end
 
       it "returns the sunset azimuth on 1986-03-10" do
-        date = Date.new(1986, 3, 10)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(1986, 3, 10)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(42.37),
           longitude: Astronoby::Angle.from_degrees(-71.05)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         setting_azimuth = observation_events.setting_azimuth
@@ -594,13 +610,12 @@ RSpec.describe Astronoby::Sun do
       end
 
       it "returns the sunset azimuth on 1991-03-14" do
-        date = Date.new(1991, 3, 14)
-        epoch = Astronoby::Epoch.from_time(date)
+        time = Time.utc(1991, 3, 14)
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(48.8566),
           longitude: Astronoby::Angle.from_degrees(2.3522)
         )
-        sun = described_class.new(epoch: epoch)
+        sun = described_class.new(time: time)
         observation_events = sun.observation_events(observer: observer)
 
         setting_azimuth = observation_events.setting_azimuth
@@ -613,13 +628,12 @@ RSpec.describe Astronoby::Sun do
 
   describe "#transit_altitude" do
     it "returns an Angle" do
-      date = Date.new
-      epoch = Astronoby::Epoch.from_time(date)
+      time = Time.new
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.zero,
         longitude: Astronoby::Angle.zero
       )
-      sun = described_class.new(epoch: epoch)
+      sun = described_class.new(time: time)
       observation_events = sun.observation_events(observer: observer)
 
       altitude = observation_events.transit_altitude
@@ -628,13 +642,12 @@ RSpec.describe Astronoby::Sun do
     end
 
     it "returns the Sun's altitude at transit on 2015-02-05" do
-      date = Date.new(2015, 2, 5)
-      epoch = Astronoby::Epoch.from_time(date)
+      time = Time.utc(2015, 2, 5)
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_degrees(38),
         longitude: Astronoby::Angle.from_degrees(-78)
       )
-      sun = described_class.new(epoch: epoch)
+      sun = described_class.new(time: time)
       observation_events = sun.observation_events(observer: observer)
 
       altitude = observation_events.transit_altitude
@@ -645,13 +658,12 @@ RSpec.describe Astronoby::Sun do
     end
 
     it "returns the Sun's altitude at transit on 1986-03-10" do
-      date = Date.new(1986, 3, 10)
-      epoch = Astronoby::Epoch.from_time(date)
+      time = Time.utc(1986, 3, 10)
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_degrees(42.37),
         longitude: Astronoby::Angle.from_degrees(-71.05)
       )
-      sun = described_class.new(epoch: epoch)
+      sun = described_class.new(time: time)
       observation_events = sun.observation_events(observer: observer)
 
       altitude = observation_events.transit_altitude
@@ -661,13 +673,12 @@ RSpec.describe Astronoby::Sun do
     end
 
     it "returns the Sun's altitude at transit on 1991-03-14" do
-      date = Date.new(1991, 3, 14)
-      epoch = Astronoby::Epoch.from_time(date)
+      time = Time.utc(1991, 3, 14)
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_degrees(48.8566),
         longitude: Astronoby::Angle.from_degrees(2.3522)
       )
-      sun = described_class.new(epoch: epoch)
+      sun = described_class.new(time: time)
       observation_events = sun.observation_events(observer: observer)
 
       altitude = observation_events.transit_altitude

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -495,7 +495,7 @@ RSpec.describe Astronoby::Sun do
 
         setting_time = observation_events.setting_time
 
-        expect(setting_time).to eq Time.utc(1991, 3, 14, 17, 53, 26)
+        expect(setting_time).to eq Time.utc(1991, 3, 14, 17, 53, 25)
         # Time from IMCCE: 1991-03-14T17:52:00
       end
     end
@@ -536,7 +536,7 @@ RSpec.describe Astronoby::Sun do
 
         rising_azimuth = observation_events.rising_azimuth
 
-        expect(rising_azimuth.str(:dms)).to eq "+109° 46′ 42.044″"
+        expect(rising_azimuth.str(:dms)).to eq "+109° 46′ 43.145″"
         # Time from SkySafari: +109° 41′ 0.3″
         # Time from IMCCE: +109° 52′ 42″
       end
@@ -552,7 +552,7 @@ RSpec.describe Astronoby::Sun do
 
         rising_azimuth = observation_events.rising_azimuth
 
-        expect(rising_azimuth.str(:dms)).to eq "+95° 1′ 6.1239″"
+        expect(rising_azimuth.str(:dms)).to eq "+95° 1′ 7.3542″"
         # Time from IMCCE: +95° 01′ 55″
       end
 
@@ -567,7 +567,7 @@ RSpec.describe Astronoby::Sun do
 
         rising_azimuth = observation_events.rising_azimuth
 
-        expect(rising_azimuth.str(:dms)).to eq "+93° 33′ 32.6479″"
+        expect(rising_azimuth.str(:dms)).to eq "+93° 33′ 34.0996″"
         # Time from IMCCE: +93° 25′ 58″
       end
     end
@@ -589,7 +589,7 @@ RSpec.describe Astronoby::Sun do
 
         setting_azimuth = observation_events.setting_azimuth
 
-        expect(setting_azimuth.str(:dms)).to eq "+250° 23′ 34.7232″"
+        expect(setting_azimuth.str(:dms)).to eq "+250° 23′ 33.614″"
         # Time from SkySafari: +250° 29′ 23.6″
         # Time from IMCCE: +250° 17′ 34″
       end
@@ -605,7 +605,7 @@ RSpec.describe Astronoby::Sun do
 
         setting_azimuth = observation_events.setting_azimuth
 
-        expect(setting_azimuth.str(:dms)).to eq "+265° 14′ 20.6301″"
+        expect(setting_azimuth.str(:dms)).to eq "+265° 14′ 19.3963″"
         # Time from IMCCE: +265° 13′ 32″
       end
 
@@ -620,7 +620,7 @@ RSpec.describe Astronoby::Sun do
 
         setting_azimuth = observation_events.setting_azimuth
 
-        expect(setting_azimuth.str(:dms)).to eq "+266° 44′ 3.7751″"
+        expect(setting_azimuth.str(:dms)).to eq "+266° 44′ 2.3191″"
         # Time from IMCCE: +266° 51′ 37″
       end
     end
@@ -652,7 +652,7 @@ RSpec.describe Astronoby::Sun do
 
       altitude = observation_events.transit_altitude
 
-      expect(altitude&.str(:dms)).to eq "+36° 8′ 16.6162″"
+      expect(altitude&.str(:dms)).to eq "+36° 8′ 15.7638″"
       # Time from SkySafari: +36° 9′ 32.5″
       # Time from IMCCE: +36° 8′ 0.3″
     end
@@ -668,7 +668,7 @@ RSpec.describe Astronoby::Sun do
 
       altitude = observation_events.transit_altitude
 
-      expect(altitude&.str(:dms)).to eq "+43° 36′ 0.1105″"
+      expect(altitude&.str(:dms)).to eq "+43° 35′ 59.2014″"
       # Time from IMCCE: +45° 35′ 41″
     end
 
@@ -683,7 +683,7 @@ RSpec.describe Astronoby::Sun do
 
       altitude = observation_events.transit_altitude
 
-      expect(altitude&.str(:dms)).to eq "+38° 31′ 33.382″"
+      expect(altitude&.str(:dms)).to eq "+38° 31′ 32.4262″"
       # Time from IMCCE: +38° 31′ 20″
     end
   end

--- a/spec/astronoby/events/twilight_events_spec.rb
+++ b/spec/astronoby/events/twilight_events_spec.rb
@@ -3,8 +3,7 @@
 RSpec.describe Astronoby::Events::TwilightEvents do
   describe "#morning_civil_twilight_time" do
     it "returns a time" do
-      epoch = Astronoby::Epoch.from_time(Date.new)
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.new)
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.zero,
         longitude: Astronoby::Angle.zero
@@ -15,8 +14,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
     end
 
     it "returns when the morning civil twilight starts" do
-      epoch = Astronoby::Epoch.from_time(Time.utc(1979, 9, 7))
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.utc(1979, 9, 7))
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_degrees(52),
         longitude: Astronoby::Angle.zero
@@ -29,8 +27,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
     end
 
     it "returns when the morning civil twilight starts" do
-      epoch = Astronoby::Epoch.from_time(Time.utc(2024, 3, 14))
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.utc(2024, 3, 14))
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_dms(-33, 52, 4),
         longitude: Astronoby::Angle.from_dms(151, 12, 26)
@@ -44,8 +41,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
 
     context "when the civil twilight doesn't start" do
       it "returns nil" do
-        epoch = Astronoby::Epoch.from_time(Time.utc(2024, 6, 20))
-        sun = Astronoby::Sun.new(epoch: epoch)
+        sun = Astronoby::Sun.new(time: Time.utc(2024, 6, 20))
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(65),
           longitude: Astronoby::Angle.zero
@@ -59,8 +55,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
 
   describe "#evening_civil_twilight_time" do
     it "returns a time" do
-      epoch = Astronoby::Epoch.from_time(Date.new)
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.new)
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.zero,
         longitude: Astronoby::Angle.zero
@@ -71,8 +66,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
     end
 
     it "returns when the evening civil twilight ends" do
-      epoch = Astronoby::Epoch.from_time(Time.utc(1979, 9, 7))
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.utc(1979, 9, 7))
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_degrees(52),
         longitude: Astronoby::Angle.zero
@@ -85,8 +79,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
     end
 
     it "returns when the evening civil twilight ends" do
-      epoch = Astronoby::Epoch.from_time(Time.utc(2024, 3, 14))
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.utc(2024, 3, 14))
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_dms(-33, 52, 4),
         longitude: Astronoby::Angle.from_dms(151, 12, 26)
@@ -100,8 +93,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
 
     context "when the civil twilight doesn't start" do
       it "returns nil" do
-        epoch = Astronoby::Epoch.from_time(Time.utc(2024, 6, 20))
-        sun = Astronoby::Sun.new(epoch: epoch)
+        sun = Astronoby::Sun.new(time: Time.utc(2024, 6, 20))
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(65),
           longitude: Astronoby::Angle.zero
@@ -115,8 +107,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
 
   describe "#morning_nautical_twilight_time" do
     it "returns a time" do
-      epoch = Astronoby::Epoch.from_time(Date.new)
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.new)
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.zero,
         longitude: Astronoby::Angle.zero
@@ -127,8 +118,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
     end
 
     it "returns when the morning nautical twilight starts" do
-      epoch = Astronoby::Epoch.from_time(Time.utc(1979, 9, 7))
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.utc(1979, 9, 7))
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_degrees(52),
         longitude: Astronoby::Angle.zero
@@ -141,8 +131,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
     end
 
     it "returns when the morning nautical twilight starts" do
-      epoch = Astronoby::Epoch.from_time(Time.utc(2024, 3, 14))
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.utc(2024, 3, 14))
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_dms(-33, 52, 4),
         longitude: Astronoby::Angle.from_dms(151, 12, 26)
@@ -156,8 +145,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
 
     context "when the nautical twilight doesn't start" do
       it "returns nil" do
-        epoch = Astronoby::Epoch.from_time(Time.utc(2024, 6, 20))
-        sun = Astronoby::Sun.new(epoch: epoch)
+        sun = Astronoby::Sun.new(time: Time.utc(2024, 6, 20))
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(55),
           longitude: Astronoby::Angle.zero
@@ -171,8 +159,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
 
   describe "#evening_nautical_twilight_time" do
     it "returns a time" do
-      epoch = Astronoby::Epoch.from_time(Date.new)
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.new)
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.zero,
         longitude: Astronoby::Angle.zero
@@ -183,8 +170,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
     end
 
     it "returns when the evening nautical twilight ends" do
-      epoch = Astronoby::Epoch.from_time(Time.utc(1979, 9, 7))
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.utc(1979, 9, 7))
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_degrees(52),
         longitude: Astronoby::Angle.zero
@@ -197,8 +183,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
     end
 
     it "returns when the evening nautical twilight ends" do
-      epoch = Astronoby::Epoch.from_time(Time.utc(2024, 3, 14))
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.utc(2024, 3, 14))
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_dms(-33, 52, 4),
         longitude: Astronoby::Angle.from_dms(151, 12, 26)
@@ -212,8 +197,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
 
     context "when the nautical twilight doesn't start" do
       it "returns nil" do
-        epoch = Astronoby::Epoch.from_time(Time.utc(2024, 6, 20))
-        sun = Astronoby::Sun.new(epoch: epoch)
+        sun = Astronoby::Sun.new(time: Time.utc(2024, 6, 20))
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(55),
           longitude: Astronoby::Angle.zero
@@ -227,8 +211,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
 
   describe "#morning_astronomical_twilight_time" do
     it "returns a time" do
-      epoch = Astronoby::Epoch.from_time(Date.new)
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.new)
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.zero,
         longitude: Astronoby::Angle.zero
@@ -244,8 +227,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
     #  Edition: Cambridge University Press
     #  Chapter: 50 - Twilight, p.114
     it "returns when the morning astronomical twilight starts" do
-      epoch = Astronoby::Epoch.from_time(Time.utc(1979, 9, 7))
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.utc(1979, 9, 7))
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_degrees(52),
         longitude: Astronoby::Angle.zero
@@ -259,8 +241,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
     end
 
     it "returns when the morning astronomical twilight starts" do
-      epoch = Astronoby::Epoch.from_time(Time.utc(2024, 3, 14))
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.utc(2024, 3, 14))
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_dms(-33, 52, 4),
         longitude: Astronoby::Angle.from_dms(151, 12, 26)
@@ -274,8 +255,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
 
     context "when the astronomical twilight doesn't start" do
       it "returns nil" do
-        epoch = Astronoby::Epoch.from_time(Time.utc(2024, 6, 20))
-        sun = Astronoby::Sun.new(epoch: epoch)
+        sun = Astronoby::Sun.new(time: Time.utc(2024, 6, 20))
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(49),
           longitude: Astronoby::Angle.zero
@@ -289,8 +269,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
 
   describe "#evening_astronomical_twilight_time" do
     it "returns a time" do
-      epoch = Astronoby::Epoch.from_time(Date.new)
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.new)
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.zero,
         longitude: Astronoby::Angle.zero
@@ -306,8 +285,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
     #  Edition: Cambridge University Press
     #  Chapter: 50 - Twilight, p.114
     it "returns when the evening astronomical twilight ends" do
-      epoch = Astronoby::Epoch.from_time(Time.utc(1979, 9, 7))
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.utc(1979, 9, 7))
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_degrees(52),
         longitude: Astronoby::Angle.zero
@@ -321,8 +299,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
     end
 
     it "returns when the evening astronomical twilight ends" do
-      epoch = Astronoby::Epoch.from_time(Time.utc(2024, 3, 14))
-      sun = Astronoby::Sun.new(epoch: epoch)
+      sun = Astronoby::Sun.new(time: Time.utc(2024, 3, 14))
       observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_dms(-33, 52, 4),
         longitude: Astronoby::Angle.from_dms(151, 12, 26)
@@ -336,8 +313,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
 
     context "when the astronomical twilight doesn't start" do
       it "returns nil" do
-        epoch = Astronoby::Epoch.from_time(Time.utc(2024, 6, 20))
-        sun = Astronoby::Sun.new(epoch: epoch)
+        sun = Astronoby::Sun.new(time: Time.utc(2024, 6, 20))
         observer = Astronoby::Observer.new(
           latitude: Astronoby::Angle.from_degrees(49),
           longitude: Astronoby::Angle.zero


### PR DESCRIPTION
Before, `Astronoby::Sun` would expect an `epoch` (`Float`) key argument as
initializer param.

Now, it expects a `time` (`Time`) argument.

This is more convenient because an epoch doesn't provide information
about the observer's time zone.
`Time.new(1991, 3, 14, 6, 0, 0, "+10:00")` and
`Time.utc(1991, 3, 13, 20, 0, 0)` are the same instant in time, and are
converted to the same Julian Day, but they do not represent the same day
depending on if we consider the time zone.
If a developer provides a local time with a time zone, they would expect
to receive sunrise and sunset times from the given day, not the one
represented from the time in UTC.

This change fixes this behaviour and includes two new tests to ensure
the local day is preserved when the provided time is not in UTC.