### PR TITLE
Twilight times better accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,22 +131,22 @@ observer = Astronoby::Observer.new(
 twilight_events = sun.twilight_events(observer: observer)
 
 twilight_events.morning_astronomical_twilight_time
-# => 2024-01-01 05:47:14 UTC
+# => 2024-01-01 05:49:25 UTC
 
 twilight_events.morning_nautical_twilight_time
-# => 2024-01-01 06:25:31 UTC
+# => 2024-01-01 06:27:42 UTC
 
 twilight_events.morning_civil_twilight_time
-# => 2024-01-01 07:05:41 UTC
+# => 2024-01-01 07:07:50 UTC
 
 twilight_events.evening_civil_twilight_time
-# => 2024-01-01 16:37:24 UTC
+# => 2024-01-01 16:40:01 UTC
 
 twilight_events.evening_nautical_twilight_time
-# => 2024-01-01 17:17:34 UTC
+# => 2024-01-01 17:20:10 UTC
 
 twilight_events.evening_astronomical_twilight_time
-# => 2024-01-01 17:55:51 UTC
+# => 2024-01-01 17:58:26 UTC
 ```
 
 ### Solstice and Equinox times

--- a/lib/astronoby/events/twilight_events.rb
+++ b/lib/astronoby/events/twilight_events.rb
@@ -92,19 +92,18 @@ module Astronoby
       end
 
       def midday
-        utc_from_epoch = Epoch.to_utc(@sun.epoch)
-        Time.utc(
-          utc_from_epoch.year,
-          utc_from_epoch.month,
-          utc_from_epoch.day,
-          12
-        )
+        date = @sun.time.to_date
+        Time.utc(date.year, date.month, date.day, 12)
+      end
+
+      def sun_at_midday
+        Sun.new(time: midday)
       end
 
       def equatorial_coordinates_at_midday
-        @equatorial_coordinates_at_midday ||=
-          @sun.apparent_ecliptic_coordinates
-            .to_apparent_equatorial(epoch: Epoch.from_time(midday))
+        @equatorial_coordinates_at_midday ||= sun_at_midday
+          .apparent_ecliptic_coordinates
+          .to_apparent_equatorial(epoch: Epoch.from_time(midday))
       end
     end
   end

--- a/lib/astronoby/events/twilight_events.rb
+++ b/lib/astronoby/events/twilight_events.rb
@@ -41,6 +41,17 @@ module Astronoby
         end
       end
 
+      # @param period_of_the_day [Symbol] :morning or :evening
+      # @param zenith_angle [Angle] The zenith angle of the twilight
+      def time_for_zenith_angle(period_of_the_day:, zenith_angle:)
+        unless PERIODS_OF_THE_DAY.include?(period_of_the_day)
+          raise IncompatibleArgumentsError,
+            "Only #{PERIODS_OF_THE_DAY.join(" or ")} are allowed as period_of_the_day, got #{period_of_the_day}"
+        end
+
+        compute(period_of_the_day, zenith_angle)
+      end
+
       private
 
       # Source:

--- a/spec/astronoby/events/twilight_events_spec.rb
+++ b/spec/astronoby/events/twilight_events_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       twilight_events = described_class.new(observer: observer, sun: sun)
 
       expect(twilight_events.morning_civil_twilight_time)
-        .to eq Time.utc(1979, 9, 7, 4, 44, 23)
+        .to eq Time.utc(1979, 9, 7, 4, 47, 13)
       # Time from IMCCE: 04:46
     end
 
@@ -35,7 +35,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       twilight_events = described_class.new(observer: observer, sun: sun)
 
       expect(twilight_events.morning_civil_twilight_time)
-        .to eq Time.utc(2024, 3, 14, 19, 25, 38)
+        .to eq Time.utc(2024, 3, 14, 19, 28, 0)
       # Time from IMCCE: 19:29:29
     end
 
@@ -74,7 +74,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       twilight_events = described_class.new(observer: observer, sun: sun)
 
       expect(twilight_events.evening_civil_twilight_time)
-        .to eq Time.utc(1979, 9, 7, 19, 8, 22)
+        .to eq Time.utc(1979, 9, 7, 19, 9, 8)
       # Time from IMCCE: 19:10
     end
 
@@ -87,7 +87,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       twilight_events = described_class.new(observer: observer, sun: sun)
 
       expect(twilight_events.evening_civil_twilight_time)
-        .to eq Time.utc(2024, 3, 14, 8, 38, 28)
+        .to eq Time.utc(2024, 3, 14, 8, 39, 45)
       # Time from IMCCE: 08:39:23
     end
 
@@ -126,7 +126,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       twilight_events = described_class.new(observer: observer, sun: sun)
 
       expect(twilight_events.morning_nautical_twilight_time)
-        .to eq Time.utc(1979, 9, 7, 4, 2, 11)
+        .to eq Time.utc(1979, 9, 7, 4, 5, 7)
       # Time from IMCCE: 04:03
     end
 
@@ -139,7 +139,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       twilight_events = described_class.new(observer: observer, sun: sun)
 
       expect(twilight_events.morning_nautical_twilight_time)
-        .to eq Time.utc(2024, 3, 14, 18, 56, 26)
+        .to eq Time.utc(2024, 3, 14, 18, 58, 49)
       # Time from IMCCE: 19:00:13
     end
 
@@ -178,7 +178,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       twilight_events = described_class.new(observer: observer, sun: sun)
 
       expect(twilight_events.evening_nautical_twilight_time)
-        .to eq Time.utc(1979, 9, 7, 19, 50, 34)
+        .to eq Time.utc(1979, 9, 7, 19, 51, 14)
       # Time from IMCCE: 19:52
     end
 
@@ -191,7 +191,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       twilight_events = described_class.new(observer: observer, sun: sun)
 
       expect(twilight_events.evening_nautical_twilight_time)
-        .to eq Time.utc(2024, 3, 14, 9, 7, 39)
+        .to eq Time.utc(2024, 3, 14, 9, 8, 56)
       # Time from IMCCE: 09:08:37
     end
 
@@ -235,7 +235,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       twilight_events = described_class.new(observer: observer, sun: sun)
 
       expect(twilight_events.morning_astronomical_twilight_time)
-        .to eq Time.utc(1979, 9, 7, 3, 16, 13)
+        .to eq Time.utc(1979, 9, 7, 3, 19, 20)
       # Time from Practical Astronomy: 03:12
       # Time from IMCCE: 03:17
     end
@@ -249,7 +249,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       twilight_events = described_class.new(observer: observer, sun: sun)
 
       expect(twilight_events.morning_astronomical_twilight_time)
-        .to eq Time.utc(2024, 3, 14, 18, 26, 47)
+        .to eq Time.utc(2024, 3, 14, 18, 29, 12)
       # Time from IMCCE: 18:30:31
     end
 
@@ -293,7 +293,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       twilight_events = described_class.new(observer: observer, sun: sun)
 
       expect(twilight_events.evening_astronomical_twilight_time)
-        .to eq Time.utc(1979, 9, 7, 20, 36, 33)
+        .to eq Time.utc(1979, 9, 7, 20, 37, 1)
       # Time from Practical Astronomy: 20:43
       # Time from IMCCE: 20:37
     end
@@ -307,7 +307,7 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       twilight_events = described_class.new(observer: observer, sun: sun)
 
       expect(twilight_events.evening_astronomical_twilight_time)
-        .to eq Time.utc(2024, 3, 14, 9, 37, 18)
+        .to eq Time.utc(2024, 3, 14, 9, 38, 33)
       # Time from IMCCE: 09:38:17
     end
 

--- a/spec/astronoby/events/twilight_events_spec.rb
+++ b/spec/astronoby/events/twilight_events_spec.rb
@@ -324,4 +324,42 @@ RSpec.describe Astronoby::Events::TwilightEvents do
       end
     end
   end
+
+  describe "#time_for_zenith_angle" do
+    it "returns a time" do
+      sun = Astronoby::Sun.new(time: Time.new)
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.zero,
+        longitude: Astronoby::Angle.zero
+      )
+      twilight_events = described_class.new(observer: observer, sun: sun)
+      zenith_angle = Astronoby::Angle.from_degrees(90 + 17)
+
+      time = twilight_events.time_for_zenith_angle(
+        period_of_the_day: :morning,
+        zenith_angle: zenith_angle
+      )
+
+      expect(time).to be_a(Time)
+    end
+
+    context "when the period of time is incompatible" do
+      it "raises an error" do
+        sun = Astronoby::Sun.new(time: Time.new)
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.zero,
+          longitude: Astronoby::Angle.zero
+        )
+        twilight_events = described_class.new(observer: observer, sun: sun)
+        zenith_angle = Astronoby::Angle.zero
+
+        expect {
+          twilight_events.time_for_zenith_angle(
+            period_of_the_day: :afternoon,
+            zenith_angle: zenith_angle
+          )
+        }.to raise_error(Astronoby::IncompatibleArgumentsError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This improves twilight times calculations on multiple levels:
- accuracy: it fixes a bug where the "sun at midday" wasn't really at midday
- code quality: the private method `#compute` has less dependencies and can be used by other methods
- flexibility: `#time_for_zenith_angle` method is added for anyone interested in a twilight time different than civil, nautical or astronomical.