### PR TITLE
Use Observer in Horizontal coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ angle.cos
 ### Coordinates conversion
 
 ```rb
+observer = Astronoby::Observer.new(
+  latitude: Astronoby::Angle.from_degrees(38),
+  longitude: Astronoby::Angle.from_degrees(-78)
+)
+
 equatorial = Astronoby::Coordinates::Equatorial.new(
   right_ascension: Astronoby::Angle.from_hms(17, 43, 54),
   declination: Astronoby::Angle.from_dms(-22, 10, 0)
@@ -56,8 +61,7 @@ equatorial = Astronoby::Coordinates::Equatorial.new(
 
 horizontal = equatorial.to_horizontal(
   time: Time.new(2016, 1, 21, 21, 30, 0, "-05:00"),
-  latitude: Astronoby::Angle.from_degrees(38),
-  longitude: Astronoby::Angle.from_degrees(-78)
+  observer: observer
 )
 
 horizontal.altitude.str(:dms)
@@ -72,15 +76,14 @@ horizontal.azimuth.str(:dms)
 ```rb
 time = Time.utc(2023, 2, 17, 11, 0, 0)
 
-latitude = Astronoby::Angle.from_degrees(48.8566)
-longitude = Astronoby::Angle.from_degrees(2.3522)
+observer = Astronoby::Observer.new(
+  latitude: Astronoby::Angle.from_degrees(48.8566),
+  longitude: Astronoby::Angle.from_degrees(2.3522)
+)
 
 sun = Astronoby::Sun.new(time: time)
 
-horizontal_coordinates = sun.horizontal_coordinates(
-  latitude: latitude,
-  longitude: longitude
-)
+horizontal_coordinates = sun.horizontal_coordinates(observer: observer)
 
 horizontal_coordinates.altitude.degrees
 # => 27.500082409271247

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -101,13 +101,12 @@ module Astronoby
 
     # Computes the Sun's horizontal coordinates
     #
-    # @param latitude [Astronoby::Angle] Latitude of the observer
-    # @param longitude [Astronoby::Angle] Longitude of the observer
+    # @param observer [Astronoby::Observer] Observer of the event
     # @return [Astronoby::Coordinates::Horizontal] Sun's horizontal coordinates
-    def horizontal_coordinates(latitude:, longitude:)
+    def horizontal_coordinates(observer:)
       apparent_ecliptic_coordinates
         .to_apparent_equatorial(epoch: epoch)
-        .to_horizontal(time: @time, latitude: latitude, longitude: longitude)
+        .to_horizontal(time: @time, observer: observer)
     end
 
     # @param observer [Astronoby::Observer] Observer of the event

--- a/lib/astronoby/coordinates/equatorial.rb
+++ b/lib/astronoby/coordinates/equatorial.rb
@@ -28,7 +28,9 @@ module Astronoby
         Angle.from_hours(ha)
       end
 
-      def to_horizontal(time:, latitude:, longitude:)
+      def to_horizontal(time:, observer:)
+        latitude = observer.latitude
+        longitude = observer.longitude
         ha = @hour_angle || compute_hour_angle(time: time, longitude: longitude)
         t0 = @declination.sin * latitude.sin +
           @declination.cos * latitude.cos * ha.cos
@@ -46,8 +48,7 @@ module Astronoby
         Horizontal.new(
           azimuth: azimuth,
           altitude: altitude,
-          latitude: latitude,
-          longitude: longitude
+          observer: observer
         )
       end
 

--- a/lib/astronoby/coordinates/horizontal.rb
+++ b/lib/astronoby/coordinates/horizontal.rb
@@ -3,30 +3,28 @@
 module Astronoby
   module Coordinates
     class Horizontal
-      attr_reader :azimuth, :altitude, :latitude, :longitude
+      attr_reader :azimuth, :altitude, :observer
 
       def initialize(
         azimuth:,
         altitude:,
-        latitude:,
-        longitude:
+        observer:
       )
         @azimuth = azimuth
         @altitude = altitude
-        @latitude = latitude
-        @longitude = longitude
+        @observer = observer
       end
 
       def to_equatorial(time:)
-        t0 = @altitude.sin * @latitude.sin +
-          @altitude.cos * @latitude.cos * @azimuth.cos
+        t0 = @altitude.sin * latitude.sin +
+          @altitude.cos * latitude.cos * @azimuth.cos
 
         declination = Angle.asin(t0)
 
-        t1 = @altitude.sin - @latitude.sin * declination.sin
+        t1 = @altitude.sin - latitude.sin * declination.sin
 
         hour_angle_degrees = Angle
-          .acos(t1 / (@latitude.cos * declination.cos))
+          .acos(t1 / (latitude.cos * declination.cos))
           .degrees
 
         if @azimuth.sin.positive?
@@ -38,7 +36,7 @@ module Astronoby
         hour_angle_hours = Angle.from_degrees(hour_angle_degrees).hours
         lst = GreenwichSiderealTime
           .from_utc(time.utc)
-          .to_lst(longitude: @longitude)
+          .to_lst(longitude: longitude)
         right_ascension_decimal = lst.time - hour_angle_hours
 
         if right_ascension_decimal.negative?
@@ -51,6 +49,16 @@ module Astronoby
           right_ascension: right_ascension,
           declination: declination
         )
+      end
+
+      private
+
+      def latitude
+        @observer.latitude
+      end
+
+      def longitude
+        @observer.longitude
       end
     end
   end

--- a/lib/astronoby/refraction.rb
+++ b/lib/astronoby/refraction.rb
@@ -5,17 +5,16 @@ module Astronoby
     LOW_ALTITUDE_BODY_ANGLE = Angle.from_degrees(15)
     ZENITH = Angle.from_degrees(90)
 
-    def self.angle(coordinates:, observer:)
-      new(coordinates, observer).refraction_angle
+    def self.angle(coordinates:)
+      new(coordinates).refraction_angle
     end
 
-    def self.correct_horizontal_coordinates(coordinates:, observer:)
-      new(coordinates, observer).refract
+    def self.correct_horizontal_coordinates(coordinates:)
+      new(coordinates).refract
     end
 
-    def initialize(coordinates, observer)
+    def initialize(coordinates)
       @coordinates = coordinates
-      @observer = observer
     end
 
     # Source:
@@ -27,8 +26,7 @@ module Astronoby
       Coordinates::Horizontal.new(
         azimuth: @coordinates.azimuth,
         altitude: @coordinates.altitude + refraction_angle,
-        latitude: @coordinates.latitude,
-        longitude: @coordinates.longitude
+        observer: @coordinates.observer
       )
     end
 
@@ -43,11 +41,11 @@ module Astronoby
     private
 
     def pressure
-      @_pressure ||= @observer.pressure
+      @_pressure ||= @coordinates.observer.pressure
     end
 
     def temperature
-      @_temperature ||= @observer.temperature
+      @_temperature ||= @coordinates.observer.temperature
     end
 
     def altitude_in_degrees

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -88,13 +88,14 @@ RSpec.describe Astronoby::Sun do
   describe "#horizontal_coordinates" do
     it "returns horizontal coordinates" do
       time = Time.new
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_degrees(-20),
+        longitude: Astronoby::Angle.from_degrees(-30)
+      )
 
       coordinates = described_class
         .new(time: time)
-        .horizontal_coordinates(
-          latitude: Astronoby::Angle.from_degrees(-20),
-          longitude: Astronoby::Angle.from_degrees(-30)
-        )
+        .horizontal_coordinates(observer: observer)
 
       expect(coordinates).to be_a(Astronoby::Coordinates::Horizontal)
     end
@@ -107,11 +108,12 @@ RSpec.describe Astronoby::Sun do
     it "computes the horizontal coordinates for the epoch" do
       time = Time.new(2015, 2, 5, 12, 0, 0, "-05:00")
       sun = described_class.new(time: time)
-
-      horizontal_coordinates = sun.horizontal_coordinates(
+      observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_degrees(38),
         longitude: Astronoby::Angle.from_degrees(-78)
       )
+
+      horizontal_coordinates = sun.horizontal_coordinates(observer: observer)
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
         eq("+35° 47′ 15.717″")
@@ -131,11 +133,12 @@ RSpec.describe Astronoby::Sun do
     it "computes the coordinates for a given epoch" do
       time = Time.new(2000, 8, 9, 12, 0, 0, "-05:00")
       sun = described_class.new(time: time)
-
-      horizontal_coordinates = sun.horizontal_coordinates(
+      observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_degrees(30),
         longitude: Astronoby::Angle.from_degrees(-95)
       )
+
+      horizontal_coordinates = sun.horizontal_coordinates(observer: observer)
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
         eq("+65° 42′ 21.6058″")
@@ -155,11 +158,12 @@ RSpec.describe Astronoby::Sun do
     it "computes the coordinates for a given epoch" do
       time = Time.new(2015, 5, 6, 14, 30, 0, "-04:00")
       sun = described_class.new(time: time)
-
-      horizontal_coordinates = sun.horizontal_coordinates(
+      observer = Astronoby::Observer.new(
         latitude: Astronoby::Angle.from_degrees(-20),
         longitude: Astronoby::Angle.from_degrees(-30)
       )
+
+      horizontal_coordinates = sun.horizontal_coordinates(observer: observer)
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
         eq("+13° 34′ 7.6913″")

--- a/spec/astronoby/coordinates/equatorial_spec.rb
+++ b/spec/astronoby/coordinates/equatorial_spec.rb
@@ -30,14 +30,16 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
   describe "#to_horizontal" do
     it "returns a new instance of Astronoby::Coordinates::Horizontal" do
       time = Time.new
-      latitude = Astronoby::Angle.from_degrees(50)
-      longitude = Astronoby::Angle.zero
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_degrees(50),
+        longitude: Astronoby::Angle.zero
+      )
 
       expect(
         described_class.new(
           right_ascension: Astronoby::Angle.from_dms(23, 59, 59),
           declination: Astronoby::Angle.from_dms(89, 59, 59)
-        ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
+        ).to_horizontal(time: time, observer: observer)
       ).to be_an_instance_of(Astronoby::Coordinates::Horizontal)
     end
 
@@ -49,13 +51,15 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2016, 1, 21, 21, 30, 0, "-05:00")
-        latitude = Astronoby::Angle.from_degrees(38)
-        longitude = Astronoby::Angle.from_degrees(-78)
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(38),
+          longitude: Astronoby::Angle.from_degrees(-78)
+        )
 
         horizontal_coordinates = described_class.new(
           right_ascension: Astronoby::Angle.from_hms(17, 43, 54),
           declination: Astronoby::Angle.from_dms(-22, 10, 0)
-        ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
+        ).to_horizontal(time: time, observer: observer)
 
         expect(horizontal_coordinates.altitude.str(:dms)).to(
           eq("-73° 27′ 19.1557″")
@@ -74,13 +78,15 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2016, 1, 21, 21, 45, 0, "-05:00")
-        latitude = Astronoby::Angle.from_degrees(38)
-        longitude = Astronoby::Angle.from_degrees(-78)
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(38),
+          longitude: Astronoby::Angle.from_degrees(-78)
+        )
 
         horizontal_coordinates = described_class.new(
           right_ascension: Astronoby::Angle.from_hms(5, 54, 58),
           declination: Astronoby::Angle.from_dms(7, 29, 54)
-        ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
+        ).to_horizontal(time: time, observer: observer)
 
         expect(horizontal_coordinates.altitude.str(:dms)).to(
           eq("+59° 13′ 0.3617″")
@@ -99,13 +105,15 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2015, 12, 1, 9, 0, 0, "-08:00")
-        latitude = Astronoby::Angle.from_degrees(45)
-        longitude = Astronoby::Angle.from_degrees(-100)
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(45),
+          longitude: Astronoby::Angle.from_degrees(-100)
+        )
 
         horizontal_coordinates = described_class.new(
           right_ascension: Astronoby::Angle.from_hms(6, 0, 0),
           declination: Astronoby::Angle.from_degrees(-60)
-        ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
+        ).to_horizontal(time: time, observer: observer)
 
         expect(horizontal_coordinates.altitude.str(:dms)).to(
           eq("-59° 41′ 58.4833″")
@@ -124,14 +132,16 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
     context "with real life arguments (book example)" do
       it "computes properly" do
         time = Time.new(2015, 12, 1, 9, 0, 0, "-08:00")
-        latitude = Astronoby::Angle.from_degrees(52)
-        longitude = Astronoby::Angle.zero
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(52),
+          longitude: Astronoby::Angle.zero
+        )
 
         horizontal_coordinates = described_class.new(
           declination: Astronoby::Angle.from_dms(23, 13, 10),
           right_ascension: nil,
           hour_angle: Astronoby::Angle.from_hms(5, 51, 44)
-        ).to_horizontal(time: time, latitude: latitude, longitude: longitude)
+        ).to_horizontal(time: time, observer: observer)
 
         expect(horizontal_coordinates.altitude.str(:dms)).to(
           eq("+19° 20′ 3.6428″")

--- a/spec/astronoby/coordinates/horizontal_spec.rb
+++ b/spec/astronoby/coordinates/horizontal_spec.rb
@@ -3,12 +3,16 @@
 RSpec.describe Astronoby::Coordinates::Horizontal do
   describe "#to_equatorial" do
     it "returns a new instance of Astronoby::Coordinates::Equatorial" do
+      observer = Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_degrees(50),
+        longitude: Astronoby::Angle.zero
+      )
+
       expect(
         described_class.new(
           azimuth: Astronoby::Angle.from_degrees(100),
           altitude: Astronoby::Angle.from_degrees(80),
-          latitude: Astronoby::Angle.from_degrees(50),
-          longitude: Astronoby::Angle.zero
+          observer: observer
         ).to_equatorial(time: Time.new)
       ).to be_a(Astronoby::Coordinates::Equatorial)
     end
@@ -20,11 +24,15 @@ RSpec.describe Astronoby::Coordinates::Horizontal do
     #  Chapter: 5 - Stars in the Nighttime Sky
     context "with real life arguments (book example)" do
       it "computes properly" do
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(38),
+          longitude: Astronoby::Angle.from_degrees(-78)
+        )
+
         equatorial_coordinates = described_class.new(
           azimuth: Astronoby::Angle.from_dms(171, 5, 0),
           altitude: Astronoby::Angle.from_dms(59, 13, 0),
-          latitude: Astronoby::Angle.from_degrees(38),
-          longitude: Astronoby::Angle.from_degrees(-78)
+          observer: observer
         ).to_equatorial(time: Time.new(2016, 1, 21, 21, 45, 0, "-05:00"))
 
         expect(equatorial_coordinates.right_ascension.str(:hms)).to(
@@ -43,11 +51,15 @@ RSpec.describe Astronoby::Coordinates::Horizontal do
     #  Chapter: 5 - Stars in the Nighttime Sky
     context "with real life arguments (book example)" do
       it "computes properly" do
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(38),
+          longitude: Astronoby::Angle.from_degrees(-78)
+        )
+
         equatorial_coordinates = described_class.new(
           azimuth: Astronoby::Angle.from_dms(341, 33, 17),
           altitude: Astronoby::Angle.from_dms(-73, 27, 19),
-          latitude: Astronoby::Angle.from_degrees(38),
-          longitude: Astronoby::Angle.from_degrees(-78)
+          observer: observer
         ).to_equatorial(time: Time.new(2016, 1, 21, 21, 30, 0, "-05:00"))
 
         expect(equatorial_coordinates.right_ascension.str(:hms)).to(
@@ -66,11 +78,15 @@ RSpec.describe Astronoby::Coordinates::Horizontal do
     #  Chapter: 5 - Stars in the Nighttime Sky
     context "with real life arguments (book example)" do
       it "computes properly" do
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(38.25),
+          longitude: Astronoby::Angle.from_degrees(-78.3)
+        )
+
         equatorial_coordinates = described_class.new(
           azimuth: Astronoby::Angle.from_degrees(90),
           altitude: Astronoby::Angle.from_degrees(45),
-          latitude: Astronoby::Angle.from_degrees(38.25),
-          longitude: Astronoby::Angle.from_degrees(-78.3)
+          observer: observer
         ).to_equatorial(time: Time.new(2015, 6, 6, 21, 0, 0, "-04:00"))
 
         expect(equatorial_coordinates.right_ascension.str(:hms)).to(

--- a/spec/astronoby/events/observation_events_spec.rb
+++ b/spec/astronoby/events/observation_events_spec.rb
@@ -79,8 +79,7 @@ RSpec.describe Astronoby::Events::ObservationEvents do
       coordinates_of_the_day = Astronoby::Coordinates::Horizontal.new(
         azimuth: Astronoby::Angle.from_degrees(90),
         altitude: Astronoby::Angle.from_degrees(45),
-        latitude: Astronoby::Angle.from_degrees(38.25),
-        longitude: Astronoby::Angle.from_degrees(-78.3)
+        observer: observer
       ).to_equatorial(time: Time.new(2015, 6, 6, 21, 0, 0, offset))
       # Cancel refraction correction to match the book that ignores it
       events = described_class.new(
@@ -232,8 +231,7 @@ RSpec.describe Astronoby::Events::ObservationEvents do
       coordinates_of_the_day = Astronoby::Coordinates::Horizontal.new(
         azimuth: Astronoby::Angle.from_degrees(90),
         altitude: Astronoby::Angle.from_degrees(45),
-        latitude: Astronoby::Angle.from_degrees(38.25),
-        longitude: Astronoby::Angle.from_degrees(-78.3)
+        observer: observer
       ).to_equatorial(time: Time.new(2015, 6, 6, 21, 0, 0, offset))
       # Cancel refraction correction to match the book that ignores it
       events = described_class.new(
@@ -410,8 +408,7 @@ RSpec.describe Astronoby::Events::ObservationEvents do
       coordinates_of_the_day = Astronoby::Coordinates::Horizontal.new(
         azimuth: Astronoby::Angle.from_degrees(90),
         altitude: Astronoby::Angle.from_degrees(45),
-        latitude: Astronoby::Angle.from_degrees(38.25),
-        longitude: Astronoby::Angle.from_degrees(-78.3)
+        observer: observer
       ).to_equatorial(time: Time.new(2015, 6, 6, 21, 0, 0, offset))
       # Cancel refraction correction to match the book that ignores it
       events = described_class.new(

--- a/spec/astronoby/refraction_spec.rb
+++ b/spec/astronoby/refraction_spec.rb
@@ -3,22 +3,20 @@
 RSpec.describe Astronoby::Refraction do
   describe "::angle" do
     it "returns an Angle" do
-      coordinates = Astronoby::Coordinates::Horizontal.new(
-        azimuth: Astronoby::Angle.from_degrees(100),
-        altitude: Astronoby::Angle.from_degrees(80),
-        latitude: Astronoby::Angle.from_degrees(50),
-        longitude: Astronoby::Angle.zero
-      )
       observer = instance_double(
         Astronoby::Observer,
+        latitude: Astronoby::Angle.from_degrees(50),
+        longitude: Astronoby::Angle.zero,
         pressure: Astronoby::Observer::DEFAULT_TEMPERATURE,
         temperature: Astronoby::Observer::PRESSURE_AT_SEA_LEVEL
       )
-
-      angle = described_class.angle(
-        coordinates: coordinates,
+      coordinates = Astronoby::Coordinates::Horizontal.new(
+        azimuth: Astronoby::Angle.from_degrees(100),
+        altitude: Astronoby::Angle.from_degrees(80),
         observer: observer
       )
+
+      angle = described_class.angle(coordinates: coordinates)
 
       expect(angle).to be_a Astronoby::Angle
     end
@@ -32,27 +30,23 @@ RSpec.describe Astronoby::Refraction do
     # The book example expects a refraction angle of +0° 10′ 11.2464″
     it "computes the refraction angle" do
       time = Time.utc(1987, 3, 23, 1, 1, 24)
-      latitude = Astronoby::Angle.from_degrees(51.203611)
-      longitude = Astronoby::Angle.from_degrees(0.17)
       true_equatorial_coordinates = Astronoby::Coordinates::Equatorial.new(
         right_ascension: Astronoby::Angle.from_hms(23, 14, 0),
         declination: Astronoby::Angle.from_dms(40, 10, 0)
       )
-      true_horizontal_coordinates = true_equatorial_coordinates.to_horizontal(
-        time: time,
-        latitude: latitude,
-        longitude: longitude
-      )
       observer = instance_double(
         Astronoby::Observer,
+        latitude: Astronoby::Angle.from_degrees(51.203611),
+        longitude: Astronoby::Angle.from_degrees(0.17),
         pressure: 1012,
         temperature: 294.85
       )
-
-      angle = described_class.angle(
-        coordinates: true_horizontal_coordinates,
+      true_horizontal_coordinates = true_equatorial_coordinates.to_horizontal(
+        time: time,
         observer: observer
       )
+
+      angle = described_class.angle(coordinates: true_horizontal_coordinates)
 
       expect(angle.str(:dms)).to eq "+0° 10′ 29.3991″"
     end
@@ -63,22 +57,20 @@ RSpec.describe Astronoby::Refraction do
     #  Edition: Cambridge University Press
     #  Chapter: 37 - Refraction
     it "computes the refraction angle" do
-      coordinates = Astronoby::Coordinates::Horizontal.new(
-        azimuth: Astronoby::Angle.from_dms(283, 16, 15.70),
-        altitude: Astronoby::Angle.from_dms(19, 20, 3.64),
-        latitude: Astronoby::Angle.from_degrees(52),
-        longitude: Astronoby::Angle.zero
-      )
       observer = instance_double(
         Astronoby::Observer,
+        latitude: Astronoby::Angle.from_degrees(52),
+        longitude: Astronoby::Angle.zero,
         pressure: 1008,
         temperature: 273.15 + 13
       )
-
-      angle = described_class.angle(
-        coordinates: coordinates,
+      coordinates = Astronoby::Coordinates::Horizontal.new(
+        azimuth: Astronoby::Angle.from_dms(283, 16, 15.70),
+        altitude: Astronoby::Angle.from_dms(19, 20, 3.64),
         observer: observer
       )
+
+      angle = described_class.angle(coordinates: coordinates)
 
       expect(angle.str(:dms)).to eq "+0° 2′ 43.3668″"
     end
@@ -86,22 +78,21 @@ RSpec.describe Astronoby::Refraction do
 
   describe "::correct_horizontal_coordinates" do
     it "returns horizontal coordinates" do
-      true_coordinates = Astronoby::Coordinates::Horizontal.new(
-        azimuth: Astronoby::Angle.from_degrees(100),
-        altitude: Astronoby::Angle.from_degrees(80),
-        latitude: Astronoby::Angle.from_degrees(50),
-        longitude: Astronoby::Angle.zero
-      )
       observer = instance_double(
         Astronoby::Observer,
+        latitude: Astronoby::Angle.from_degrees(50),
+        longitude: Astronoby::Angle.zero,
         pressure: 0,
         temperature: 0
       )
-
-      apparent_coordinates = described_class.correct_horizontal_coordinates(
-        coordinates: true_coordinates,
+      true_coordinates = Astronoby::Coordinates::Horizontal.new(
+        azimuth: Astronoby::Angle.from_degrees(100),
+        altitude: Astronoby::Angle.from_degrees(80),
         observer: observer
       )
+
+      apparent_coordinates = described_class
+        .correct_horizontal_coordinates(coordinates: true_coordinates)
 
       expect(apparent_coordinates).to be_a(Astronoby::Coordinates::Horizontal)
     end
@@ -112,29 +103,26 @@ RSpec.describe Astronoby::Refraction do
     #  Edition: Cambridge University Press
     #  Chapter: 37 - Refraction
     it "computes accurate apparent coordinates" do
-      true_coordinates = Astronoby::Coordinates::Horizontal.new(
-        azimuth: Astronoby::Angle.from_dms(283, 16, 15.70),
-        altitude: Astronoby::Angle.from_dms(19, 20, 3.64),
-        latitude: Astronoby::Angle.from_degrees(52),
-        longitude: Astronoby::Angle.zero
-      )
       observer = instance_double(
         Astronoby::Observer,
+        latitude: Astronoby::Angle.from_degrees(52),
+        longitude: Astronoby::Angle.zero,
         pressure: 1008,
         temperature: 273.15 + 13
       )
-
-      apparent_coordinates = described_class.correct_horizontal_coordinates(
-        coordinates: true_coordinates,
+      true_coordinates = Astronoby::Coordinates::Horizontal.new(
+        azimuth: Astronoby::Angle.from_dms(283, 16, 15.70),
+        altitude: Astronoby::Angle.from_dms(19, 20, 3.64),
         observer: observer
       )
+
+      apparent_coordinates = described_class
+        .correct_horizontal_coordinates(coordinates: true_coordinates)
 
       expect(apparent_coordinates.azimuth).to eq(true_coordinates.azimuth)
       expect(apparent_coordinates.altitude.str(:dms)).to(
         eq("+19° 22′ 47.0068″")
       )
-      expect(apparent_coordinates.latitude).to eq(true_coordinates.latitude)
-      expect(apparent_coordinates.longitude).to eq(true_coordinates.longitude)
     end
   end
 end


### PR DESCRIPTION
Before, horizontal coordinates were initialized with the latitude and longitude angles of the observer.

Recently, `Astronoby::Observer` was introduced to encapsulate data and behaviour from an observer, out of other unrelated objects.

Now, horizontal coordinates are initialized with an observer object.

There was no behaviour change.