### PR TITLE
Move dependencies to development ones

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,6 @@ PATH
   specs:
     astronoby (0.5.0)
       matrix (~> 0.4.2)
-      rake (~> 13.0)
-      rspec (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -76,6 +74,8 @@ PLATFORMS
 
 DEPENDENCIES
   astronoby!
+  rake (~> 13.0)
+  rspec (~> 3.0)
   standard (~> 1.3)
 
 BUNDLED WITH

--- a/astronoby.gemspec
+++ b/astronoby.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "matrix", "~> 0.4.2"
-  spec.add_dependency "rake", "~> 13.0"
-  spec.add_dependency "rspec", "~> 3.0"
 
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "standard", "~> 1.3"
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
Before, `rake` and `rspec` were added as dependencies for the library itself, resulting in having to have them in any project where `astronoby` would be added.

Now, there are only development dependencies.

Fixes #98

Thank you, @trevorturk, for the suggested solution in your issue.