### PR TITLE
Fix Moon monthly phase events calculation

### DIFF
--- a/lib/astronoby/events/moon_phases.rb
+++ b/lib/astronoby/events/moon_phases.rb
@@ -23,7 +23,8 @@ module Astronoby
           MoonPhase.first_quarter(new(year, month, :first_quarter, 0.25).time),
           MoonPhase.full_moon(new(year, month, :full_moon, 0.5).time),
           MoonPhase.last_quarter(new(year, month, :last_quarter, 0.75).time),
-          MoonPhase.new_moon(new(year, month, :new_moon, 1).time)
+          MoonPhase.new_moon(new(year, month, :new_moon, 1).time),
+          MoonPhase.first_quarter(new(year, month, :first_quarter, 1.25).time)
         ].select { _1.time.month == month }
       end
 

--- a/spec/astronoby/bodies/moon_spec.rb
+++ b/spec/astronoby/bodies/moon_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe Astronoby::Moon do
 
       expect(moon_phases).to be_an(Array)
     end
+
+    it "returns correct phase events for 2025-08" do
+      moon_phases = described_class.monthly_phase_events(year: 2025, month: 8)
+      days_of_moon_phases = moon_phases.map { _1.time.day }
+
+      # Phases in August 2025 from IMCCE (days): 1, 9, 16, 23, 31
+      expect(days_of_moon_phases).to eq([1, 9, 16, 23, 31])
+    end
   end
 
   describe "#apparent_ecliptic_coordinates" do

--- a/spec/astronoby/bodies/moon_spec.rb
+++ b/spec/astronoby/bodies/moon_spec.rb
@@ -7,14 +7,6 @@ RSpec.describe Astronoby::Moon do
 
       expect(moon_phases).to be_an(Array)
     end
-
-    it "returns correct phase events for 2025-08" do
-      moon_phases = described_class.monthly_phase_events(year: 2025, month: 8)
-      days_of_moon_phases = moon_phases.map { _1.time.day }
-
-      # Phases in August 2025 from IMCCE (days): 1, 9, 16, 23, 31
-      expect(days_of_moon_phases).to eq([1, 9, 16, 23, 31])
-    end
   end
 
   describe "#apparent_ecliptic_coordinates" do

--- a/spec/astronoby/events/moon_phases_spec.rb
+++ b/spec/astronoby/events/moon_phases_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe Astronoby::Events::MoonPhases do
     # Result from IMCCE: 2024-01-25T17:54:01Z
   end
 
+  it "returns correct phase events for 2025-08" do
+    moon_phases = described_class.phases_for(year: 2025, month: 8)
+    days_of_moon_phases = moon_phases.map { _1.time.day }
+
+    # Phases in August 2025 from IMCCE (days): 1, 9, 16, 23, 31
+    expect(days_of_moon_phases).to eq([1, 9, 16, 23, 31])
+  end
+
   context "when there are more than 4 phases in a month" do
     it "returns all of them" do
       moon_phases = described_class.phases_for(year: 2024, month: 5)


### PR DESCRIPTION
Noticed 'missing' first quarter phases for August, September and October 2025 in `Astronoby::Moon.monthly_phase_events`

Including 'the next' first quarter in the calculation ensures the coverage of a 'full cycle'.