### PR TITLE
Increase precision of mean obliquity

### DIFF
--- a/lib/astronoby/mean_obliquity.rb
+++ b/lib/astronoby/mean_obliquity.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-require "date"
+# TODO: This needs to be improved by receiving an instant instead of an Epoch
+# as these coefficients work with TT (Terrestrial Time).
 
 module Astronoby
   class MeanObliquity
     # Source:
     #  IAU resolution in 2006 in favor of the P03 astronomical model
-    #  The Astronomical Almanac for 2010
+    #  https://syrte.obspm.fr/iau2006/aa03_412_P03.pdf
 
     EPOCH_OF_REFERENCE = Epoch::DEFAULT_EPOCH
     OBLIQUITY_OF_REFERENCE = 23.4392794
@@ -14,19 +15,31 @@ module Astronoby
     def self.for_epoch(epoch)
       return obliquity_of_reference if epoch == EPOCH_OF_REFERENCE
 
-      t = (epoch - EPOCH_OF_REFERENCE) / Constants::DAYS_PER_JULIAN_CENTURY
+      t = Rational(
+        (epoch - EPOCH_OF_REFERENCE),
+        Constants::DAYS_PER_JULIAN_CENTURY
+      )
 
-      Angle.from_degrees(
-        obliquity_of_reference.degrees - (
-          46.815 * t -
-          0.0006 * t * t +
-          0.00181 * t * t * t
-        ) / Constants::SECONDS_PER_DEGREE
+      epsilon0 = obliquity_of_reference_in_milliarcseconds
+      c1 = -46.836769
+      c2 = -0.0001831
+      c3 = 0.00200340
+      c4 = -0.000000576
+      c5 = -0.0000000434
+
+      Angle.from_dms(
+        0,
+        0,
+        epsilon0 + t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))))
       )
     end
 
     def self.obliquity_of_reference
-      Angle.from_dms(23, 26, 21.45)
+      Angle.from_dms(0, 0, obliquity_of_reference_in_milliarcseconds)
+    end
+
+    def self.obliquity_of_reference_in_milliarcseconds
+      84381.406
     end
   end
 end

--- a/spec/astronoby/bodies/moon_spec.rb
+++ b/spec/astronoby/bodies/moon_spec.rb
@@ -76,7 +76,8 @@ RSpec.describe Astronoby::Moon do
     #  Edition: MIT Press
     #  Chapter: 7 - The Moon, p.185
     it "returns the apparent ecliptic coordinates for 2010-05-15" do
-      moon = described_class.new(time: Time.new(2010, 5, 15, 14, 30, 0, "-04:00"))
+      moon = described_class
+        .new(time: Time.new(2010, 5, 15, 14, 30, 0, "-04:00"))
 
       coordinates = moon.apparent_ecliptic_coordinates
 
@@ -143,11 +144,11 @@ RSpec.describe Astronoby::Moon do
 
       coordinates = moon.apparent_equatorial_coordinates
 
-      expect(coordinates.right_ascension.str(:hms)).to eq "8h 58m 45.21s"
+      expect(coordinates.right_ascension.str(:hms)).to eq "8h 58m 45.2095s"
       # Result from the book: 8h 58m 45.1s
       # Result from IMCCE: 8h 58m 45.0996s
 
-      expect(coordinates.declination.str(:dms)).to eq "+13° 46′ 6.1119″"
+      expect(coordinates.declination.str(:dms)).to eq "+13° 46′ 6.0818″"
       # Result from the book: +13° 46′ 6″
       # Result from IMCCE: +13° 46′ 6.424″
     end
@@ -162,11 +163,11 @@ RSpec.describe Astronoby::Moon do
 
       coordinates = moon.apparent_equatorial_coordinates
 
-      expect(coordinates.right_ascension.str(:hms)).to eq "4h 16m 35.1442s"
+      expect(coordinates.right_ascension.str(:hms)).to eq "4h 16m 35.1446s"
       # Result from the book: 4h 15m 27.7703s (4.257714h)
       # Result from IMCCE: 4h 16m 35.0164s
 
-      expect(coordinates.declination.str(:dms)).to eq "+17° 24′ 14.7897″"
+      expect(coordinates.declination.str(:dms)).to eq "+17° 24′ 14.7471″"
       # Result from the book: +17° 14′ 55.9679″ (17.24888°)
       # Result from IMCCE: +17° 24′ 13.492″
     end
@@ -181,11 +182,11 @@ RSpec.describe Astronoby::Moon do
 
       coordinates = moon.apparent_equatorial_coordinates
 
-      expect(coordinates.right_ascension.str(:hms)).to eq "17h 6m 3.1276s"
+      expect(coordinates.right_ascension.str(:hms)).to eq "17h 6m 3.1278s"
       # Result from the book: 17h 5m 41.2872s (17.094802h)
       # Result from IMCCE: 17h 6m 3.1064s
 
-      expect(coordinates.declination.str(:dms)).to eq "-19° 39′ 20.8685″"
+      expect(coordinates.declination.str(:dms)).to eq "-19° 39′ 20.8256″"
       # Result from the book: -19° 47′ 39.9372″ (-19.794427°)
       # Result from IMCCE: -19° 39′ 20.54″
     end
@@ -196,15 +197,16 @@ RSpec.describe Astronoby::Moon do
     #  Edition: MIT Press
     #  Chapter: 7 - The Moon, p.185
     it "returns the apparent geocentric equatorial coordinates for 2010-05-15" do
-      moon = described_class.new(time: Time.new(2010, 5, 15, 14, 30, 0, "-04:00"))
+      moon = described_class
+        .new(time: Time.new(2010, 5, 15, 14, 30, 0, "-04:00"))
 
       coordinates = moon.apparent_equatorial_coordinates
 
-      expect(coordinates.right_ascension.str(:hms)).to eq "5h 0m 44.3733s"
+      expect(coordinates.right_ascension.str(:hms)).to eq "5h 0m 44.3736s"
       # Result from the book: 4h 59m 54.1103s (4.998364h)
       # Result from IMCCE: 5h 0m 44.454s
 
-      expect(coordinates.declination.str(:dms)).to eq "+25° 1′ 18.2266″"
+      expect(coordinates.declination.str(:dms)).to eq "+25° 1′ 18.1818″"
       # Result from the book: +25° 9′ 2.6999″ (25.150750°)
       # Result from IMCCE: +25° 1′ 19.227″
     end
@@ -219,11 +221,11 @@ RSpec.describe Astronoby::Moon do
 
       coordinates = moon.apparent_equatorial_coordinates
 
-      expect(coordinates.right_ascension.str(:hms)).to eq "14h 12m 12.2352s"
+      expect(coordinates.right_ascension.str(:hms)).to eq "14h 12m 12.2358s"
       # Result from the book: 14h 12m 42s
       # Result from IMCCE: 14h 12m 12.2872s
 
-      expect(coordinates.declination.str(:dms)).to eq "-11° 35′ 7.9466″"
+      expect(coordinates.declination.str(:dms)).to eq "-11° 35′ 7.9222″"
       # Result from the book: -11° 31′ 38″
       # Result from IMCCE: -11° 35′ 7.994″
     end
@@ -241,10 +243,10 @@ RSpec.describe Astronoby::Moon do
       horizontal_coordinates =
         moon.horizontal_coordinates(observer: observer)
 
-      expect(horizontal_coordinates.azimuth.str(:dms)).to eq "+245° 7′ 32.2346″"
+      expect(horizontal_coordinates.azimuth.str(:dms)).to eq "+245° 7′ 32.1829″"
       # Result from IMCCE: +245° 7′ 30.36″
 
-      expect(horizontal_coordinates.altitude.str(:dms)).to eq "+48° 1′ 21.8373″"
+      expect(horizontal_coordinates.altitude.str(:dms)).to eq "+48° 1′ 21.8119″"
       # Result from IMCCE: +48° 1′ 21″
     end
 
@@ -262,11 +264,11 @@ RSpec.describe Astronoby::Moon do
 
       coordinates = moon.horizontal_coordinates(observer: observer)
 
-      expect(coordinates.altitude.str(:dms)).to eq "-51° 19′ 13.9407″"
+      expect(coordinates.altitude.str(:dms)).to eq "-51° 19′ 13.9268″"
       # Result from the book: -50° 44′
       # Result from IMCCE: -51° 19′ 22.44″
 
-      expect(coordinates.azimuth.str(:dms)).to eq "+84° 40′ 12.0274″"
+      expect(coordinates.azimuth.str(:dms)).to eq "+84° 40′ 11.9631″"
       # Result from the book: +84° 56′
       # Result from IMCCE: +84° 40′ 5.52″
     end
@@ -281,15 +283,16 @@ RSpec.describe Astronoby::Moon do
         latitude: Astronoby::Angle.from_degrees(-20),
         longitude: Astronoby::Angle.from_degrees(-30)
       )
-      moon = described_class.new(time: Time.new(2010, 5, 15, 14, 30, 0, "-04:00"))
+      moon = described_class
+        .new(time: Time.new(2010, 5, 15, 14, 30, 0, "-04:00"))
 
       coordinates = moon.horizontal_coordinates(observer: observer)
 
-      expect(coordinates.altitude.str(:dms)).to eq "+25° 52′ 49.8989″"
+      expect(coordinates.altitude.str(:dms)).to eq "+25° 52′ 49.9323″"
       # Result from the book: 26° 32′
       # Result from IMCCE: 25° 52′ 40.8″
 
-      expect(coordinates.azimuth.str(:dms)).to eq "+313° 26′ 5.3866″"
+      expect(coordinates.azimuth.str(:dms)).to eq "+313° 26′ 5.3526″"
       # Result from the book: +313° 24′
       # Result from IMCCE: +313° 25′ 58.08″
     end
@@ -560,7 +563,7 @@ RSpec.describe Astronoby::Moon do
 
         rising_azimuth = observation_events.rising_azimuth
 
-        expect(rising_azimuth.str(:dms)).to eq "+98° 47′ 39.3589″"
+        expect(rising_azimuth.str(:dms)).to eq "+98° 47′ 39.3473″"
         # Time from IMCCE: +98° 37′ 50″
       end
     end
@@ -609,7 +612,7 @@ RSpec.describe Astronoby::Moon do
 
         transit_altitude = observation_events.transit_altitude
 
-        expect(transit_altitude.str(:dms)).to eq "+83° 1′ 50.327″"
+        expect(transit_altitude.str(:dms)).to eq "+83° 1′ 50.3358″"
         # Time from IMCCE: +82° 55′ 41″
       end
     end
@@ -658,7 +661,7 @@ RSpec.describe Astronoby::Moon do
 
         setting_azimuth = observation_events.setting_azimuth
 
-        expect(setting_azimuth.str(:dms)).to eq "+264° 34′ 51.1561″"
+        expect(setting_azimuth.str(:dms)).to eq "+264° 34′ 51.1622″"
         # Time from IMCCE: +264° 45′ 18″
       end
     end

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -75,11 +75,11 @@ RSpec.describe Astronoby::Sun do
         .to_true_equatorial(epoch: epoch)
 
       expect(equatorial_coordinates.right_ascension.str(:hms)).to(
-        eq("8h 26m 3.6131s")
+        eq("8h 26m 3.6126s")
         # Result from the book: 8h 26m 4s
       )
       expect(equatorial_coordinates.declination.str(:dms)).to(
-        eq("+19° 12′ 43.1836″")
+        eq("+19° 12′ 43.1502″")
         # Result from the book: 19° 12′ 43″
       )
     end
@@ -174,11 +174,11 @@ RSpec.describe Astronoby::Sun do
       horizontal_coordinates = sun.horizontal_coordinates(observer: observer)
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
-        eq("+35° 47′ 15.717″")
+        eq("+35° 47′ 15.7489″")
         # Result from the book: 35° 47′ 0.1″
       )
       expect(horizontal_coordinates.azimuth.str(:dms)).to(
-        eq("+172° 17′ 22.7257″")
+        eq("+172° 17′ 22.7335″")
         # Result from the book: 172° 17′ 46″
       )
     end
@@ -199,11 +199,11 @@ RSpec.describe Astronoby::Sun do
       horizontal_coordinates = sun.horizontal_coordinates(observer: observer)
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
-        eq("+65° 42′ 21.6058″")
+        eq("+65° 42′ 21.5945″")
         # Result from the book: 65° 43′
       )
       expect(horizontal_coordinates.azimuth.str(:dms)).to(
-        eq("+121° 33′ 22.4256″")
+        eq("+121° 33′ 22.4927″")
         # Result from the book: 121° 34′
       )
     end
@@ -224,11 +224,11 @@ RSpec.describe Astronoby::Sun do
       horizontal_coordinates = sun.horizontal_coordinates(observer: observer)
 
       expect(horizontal_coordinates.altitude.str(:dms)).to(
-        eq("+13° 34′ 7.6913″")
+        eq("+13° 34′ 7.7144″")
         # Result from the book: 13° 34′
       )
       expect(horizontal_coordinates.azimuth.str(:dms)).to(
-        eq("+293° 36′ 54.0812″")
+        eq("+293° 36′ 54.0556″")
         # Result from the book: 293° 37′
       )
     end
@@ -632,7 +632,7 @@ RSpec.describe Astronoby::Sun do
 
         rising_azimuth = observation_events.rising_azimuth
 
-        expect(rising_azimuth.str(:dms)).to eq "+109° 29′ 35.4732″"
+        expect(rising_azimuth.str(:dms)).to eq "+109° 29′ 35.4329″"
         # Time from SkySafari: +109° 41′ 0.3″
         # Time from IMCCE: +109° 52′ 42″
       end
@@ -648,7 +648,7 @@ RSpec.describe Astronoby::Sun do
 
         rising_azimuth = observation_events.rising_azimuth
 
-        expect(rising_azimuth.str(:dms)).to eq "+94° 45′ 0.7901″"
+        expect(rising_azimuth.str(:dms)).to eq "+94° 45′ 0.7809″"
         # Time from IMCCE: +95° 01′ 55″
       end
 
@@ -663,7 +663,7 @@ RSpec.describe Astronoby::Sun do
 
         rising_azimuth = observation_events.rising_azimuth
 
-        expect(rising_azimuth.str(:dms)).to eq "+93° 17′ 29.9686″"
+        expect(rising_azimuth.str(:dms)).to eq "+93° 17′ 29.9617″"
         # Time from IMCCE: +93° 25′ 58″
       end
     end
@@ -685,7 +685,7 @@ RSpec.describe Astronoby::Sun do
 
         setting_azimuth = observation_events.setting_azimuth
 
-        expect(setting_azimuth.str(:dms)).to eq "+250° 40′ 41.7466″"
+        expect(setting_azimuth.str(:dms)).to eq "+250° 40′ 41.7866″"
         # Time from SkySafari: +250° 29′ 23.6″
         # Time from IMCCE: +250° 17′ 34″
       end
@@ -701,7 +701,7 @@ RSpec.describe Astronoby::Sun do
 
         setting_azimuth = observation_events.setting_azimuth
 
-        expect(setting_azimuth.str(:dms)).to eq "+265° 30′ 28.1729″"
+        expect(setting_azimuth.str(:dms)).to eq "+265° 30′ 28.1817″"
         # Time from IMCCE: +265° 13′ 32″
       end
 
@@ -716,7 +716,7 @@ RSpec.describe Astronoby::Sun do
 
         setting_azimuth = observation_events.setting_azimuth
 
-        expect(setting_azimuth.str(:dms)).to eq "+267° 0′ 8.7372″"
+        expect(setting_azimuth.str(:dms)).to eq "+267° 0′ 8.7437″"
         # Time from IMCCE: +266° 51′ 37″
       end
     end
@@ -748,7 +748,7 @@ RSpec.describe Astronoby::Sun do
 
       altitude = observation_events.transit_altitude
 
-      expect(altitude&.str(:dms)).to eq "+36° 8′ 14.9673″"
+      expect(altitude&.str(:dms)).to eq "+36° 8′ 14.9983″"
       # Time from SkySafari: +36° 9′ 32.5″
       # Time from IMCCE: +36° 8′ 0.3″
     end
@@ -764,7 +764,7 @@ RSpec.describe Astronoby::Sun do
 
       altitude = observation_events.transit_altitude
 
-      expect(altitude&.str(:dms)).to eq "+43° 35′ 58.181″"
+      expect(altitude&.str(:dms)).to eq "+43° 35′ 58.1877″"
       # Time from IMCCE: +45° 35′ 41″
     end
 
@@ -779,7 +779,7 @@ RSpec.describe Astronoby::Sun do
 
       altitude = observation_events.transit_altitude
 
-      expect(altitude&.str(:dms)).to eq "+38° 31′ 31.3674″"
+      expect(altitude&.str(:dms)).to eq "+38° 31′ 31.3718″"
       # Time from IMCCE: +38° 31′ 20″
     end
   end

--- a/spec/astronoby/coordinates/ecliptic_spec.rb
+++ b/spec/astronoby/coordinates/ecliptic_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Astronoby::Coordinates::Ecliptic do
           # Result from the book: 12h 18m 47.5s
         )
         expect(equatorial_coordinates.declination.str(:dms)).to(
-          eq("-0° 43′ 35.5098″")
+          eq("-0° 43′ 35.5062″")
           # Result from the book: -0° 43′ 35.5″
         )
       end
@@ -46,11 +46,11 @@ RSpec.describe Astronoby::Coordinates::Ecliptic do
         ).to_true_equatorial(epoch: epoch)
 
         expect(equatorial_coordinates.right_ascension.str(:hms)).to(
-          eq("8h 10m 50.4188s")
+          eq("8h 10m 50.4182s")
           # Result from the book: 8h 10m 50s
         )
         expect(equatorial_coordinates.declination.str(:dms)).to(
-          eq("+20° 2′ 30.795″")
+          eq("+20° 2′ 30.758″")
           # Result from the book: +20° 2′ 31″
         )
       end
@@ -73,11 +73,11 @@ RSpec.describe Astronoby::Coordinates::Ecliptic do
         ).to_true_equatorial(epoch: epoch)
 
         expect(equatorial_coordinates.right_ascension.str(:hms)).to(
-          eq("9h 34m 53.3214s")
+          eq("9h 34m 53.3205s")
           # Result from the book: 9h 34m 53.32s
         )
         expect(equatorial_coordinates.declination.str(:dms)).to(
-          eq("+19° 32′ 6.0105″")
+          eq("+19° 32′ 5.9833″")
           # Result from the book: +19° 32′ 6.01″
         )
       end

--- a/spec/astronoby/coordinates/equatorial_spec.rb
+++ b/spec/astronoby/coordinates/equatorial_spec.rb
@@ -171,10 +171,10 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
         ).to_ecliptic(epoch: epoch)
 
         expect(ecliptic_coordinates.latitude.str(:dms)).to(
-          eq("+22° 41′ 53.8752″")
+          eq("+22° 41′ 53.8929″")
         )
         expect(ecliptic_coordinates.longitude.str(:dms)).to(
-          eq("+156° 19′ 8.9427″")
+          eq("+156° 19′ 8.9596″")
         )
       end
     end
@@ -196,10 +196,10 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
         ).to_ecliptic(epoch: epoch)
 
         expect(ecliptic_coordinates.latitude.str(:dms)).to(
-          eq("+6° 41′ 3.0103″")
+          eq("+6° 41′ 3.0508″")
         )
         expect(ecliptic_coordinates.longitude.str(:dms)).to(
-          eq("+113° 12′ 56.2651″")
+          eq("+113° 12′ 56.2671″")
         )
       end
     end
@@ -221,10 +221,10 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
         ).to_ecliptic(epoch: epoch)
 
         expect(ecliptic_coordinates.latitude.str(:dms)).to(
-          eq("+4° 52′ 30.993″")
+          eq("+4° 52′ 31.0228″")
         )
         expect(ecliptic_coordinates.longitude.str(:dms)).to(
-          eq("+139° 41′ 9.9812″")
+          eq("+139° 41′ 9.9842″")
         )
       end
     end

--- a/spec/astronoby/mean_obliquity_spec.rb
+++ b/spec/astronoby/mean_obliquity_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe Astronoby::MeanObliquity do
     it "returns the obliquity angle for standard epoch" do
       obliquity = described_class.for_epoch(Astronoby::Epoch::J2000)
 
-      expect(obliquity.degrees).to eq(23.439291666666666)
+      expect(obliquity.degrees).to eq(23.439279444444445)
     end
 
     it "returns the obliquity angle for epoch 1950" do
       obliquity = described_class.for_epoch(Astronoby::Epoch::J1950)
 
-      expect(obliquity.degrees).to eq 23.445793854513887
+      expect(obliquity.degrees).to eq 23.445784468962604
     end
 
     # Source:
@@ -30,7 +30,7 @@ RSpec.describe Astronoby::MeanObliquity do
         epoch = Astronoby::Epoch.from_time(Time.utc(2009, 7, 6, 0, 0, 0))
         obliquity = described_class.for_epoch(epoch)
 
-        expect(obliquity.str(:dms)).to eq "+23° 26′ 16.9979″"
+        expect(obliquity.str(:dms)).to eq "+23° 26′ 16.9518″"
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe Astronoby::MeanObliquity do
         epoch = Astronoby::Epoch.from_time(Time.utc(1987, 4, 10, 0, 0, 0))
         obliquity = described_class.for_epoch(epoch)
 
-        expect(obliquity.str(:dms)).to eq "+23° 26′ 27.4093″"
+        expect(obliquity.str(:dms)).to eq "+23° 26′ 27.3681″"
       end
     end
   end

--- a/spec/astronoby/true_obliquity_spec.rb
+++ b/spec/astronoby/true_obliquity_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Astronoby::TrueObliquity do
         epoch = Astronoby::Epoch.from_time(Time.utc(1987, 4, 10, 0, 0, 0))
         obliquity = described_class.for_epoch(epoch)
 
-        expect(obliquity.str(:dms)).to eq "+23° 26′ 36.8401″"
+        expect(obliquity.str(:dms)).to eq "+23° 26′ 36.7989″"
       end
     end
   end


### PR DESCRIPTION
This updates the coefficients used to compute the mean obliquity to match P03 astronomical model.

The change is really minimal (less than 0.1 arcsecond) but the goal is to be as accurate as possible.

\<teasing>This change will make more sense in the close future when we'll update the nutation coefficients using IERS data.\</teasing>

I realise how inconvenient it is to have so much test changes, this is not ideal. This is something I would like to improve in the future, so that every tiny precision increase doesn't lead to updating half of the specs.
In the meantime, that's what's happening 🤦