### PR TITLE
Ecliptic coordinates for Geometric and Astrometric reference frames

### DIFF
--- a/lib/astronoby/coordinates/ecliptic.rb
+++ b/lib/astronoby/coordinates/ecliptic.rb
@@ -10,6 +10,10 @@ module Astronoby
         @longitude = longitude
       end
 
+      def self.zero
+        new(latitude: Angle.zero, longitude: Angle.zero)
+      end
+
       # Source:
       #  Title: Celestial Calculations
       #  Author: J. L. Lawrence

--- a/lib/astronoby/reference_frame.rb
+++ b/lib/astronoby/reference_frame.rb
@@ -28,6 +28,12 @@ module Astronoby
       Coordinates::Equatorial.from_position_vector(@position)
     end
 
+    def ecliptic
+      return Coordinates::Ecliptic.zero if distance.zero?
+
+      equatorial.to_ecliptic(epoch: Epoch::J2000)
+    end
+
     def distance
       return Distance.zero if @position.zero?
 

--- a/spec/astronoby/bodies/earth_spec.rb
+++ b/spec/astronoby/bodies/earth_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Astronoby::Earth do
         .to eq("+7° 34′ 11.406″")
       # IMCCE:    +7° 34′ 11.407″
       # Skyfield: +7° 34′ 11.4″
+
+      expect(geometric.ecliptic.latitude.str(:dms))
+        .to eq("+0° 0′ 32.9716″")
+      # IMCCE:    +0° 0′ 32.971″
+      # Skyfield: +0° 0′ 33.2″
+
+      expect(geometric.ecliptic.longitude.str(:dms))
+        .to eq("+160° 40′ 55.7988″")
+      # IMCCE:    +160° 40′ 55.794″
+      # Skyfield: +160° 40′ 56.4″
+
+      expect(geometric.distance.au)
+        .to eq(0.9941296922100833)
+      # IMCCE:    0.994129567869
+      # Skyfield: 0.9941296929553649
     end
 
     it "computes the correct velocity" do
@@ -105,6 +120,8 @@ RSpec.describe Astronoby::Earth do
       expect(astrometric.equatorial.right_ascension)
         .to eq(Astronoby::Angle.zero)
       expect(astrometric.equatorial.declination).to eq(Astronoby::Angle.zero)
+      expect(astrometric.ecliptic.latitude).to eq(Astronoby::Angle.zero)
+      expect(astrometric.ecliptic.longitude).to eq(Astronoby::Angle.zero)
       expect(astrometric.distance).to eq(Astronoby::Distance.zero)
     end
 

--- a/spec/astronoby/bodies/jupiter_spec.rb
+++ b/spec/astronoby/bodies/jupiter_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Astronoby::Jupiter do
         .to eq("+23° 9′ 24.1204″")
       # IMCCE:    +23° 9′ 24.118″
       # Skyfield: +23° 9′ 24.1″
+
+      expect(geometric.ecliptic.latitude.str(:dms))
+        .to eq("-0° 16′ 22.9896″")
+      # IMCCE:    -0° 16′ 22.992″
+      # Skyfield: -0° 16′ 11.1″
+
+      expect(geometric.ecliptic.longitude.str(:dms))
+        .to eq("+88° 24′ 41.3024″")
+      # IMCCE:    +88° 24′ 41.297″
+      # Skyfield: +88° 24′ 55.4″
+
+      expect(geometric.distance.au)
+        .to eq(5.118010310588575)
+      # IMCCE:    5.11801034937
+      # Skyfield: 5.118010311352852
     end
 
     it "computes the correct velocity" do
@@ -111,6 +126,16 @@ RSpec.describe Astronoby::Jupiter do
         .to eq("+22° 53′ 40.755″")
       # IMCCE:    +22° 53′ 40.753″
       # Skyfield: +22° 53′ 40.8″
+
+      expect(astrometric.ecliptic.latitude.str(:dms))
+        .to eq("-0° 14′ 27.7664″")
+      # IMCCE:    -0° 14′ 27.769″
+      # Skyfield: -0° 14′ 15.9″
+
+      expect(astrometric.ecliptic.longitude.str(:dms))
+        .to eq("+81° 1′ 11.959″")
+      # IMCCE:    +81° 1′ 11.962″
+      # Skyfield: +81° 22′ 26.1″
 
       expect(astrometric.distance.au)
         .to eq(5.847692982822113)

--- a/spec/astronoby/bodies/mars_spec.rb
+++ b/spec/astronoby/bodies/mars_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Astronoby::Mars do
         .to eq("+13° 22′ 23.046″")
       # IMCCE:    +13° 22′ 23.048″
       # Skyfield: +13° 22′ 23.0″
+
+      expect(geometric.ecliptic.latitude.str(:dms))
+        .to eq("+1° 49′ 29.7913″")
+      # IMCCE:    +1° 49′ 29.791″
+      # Skyfield: +1° 49′ 34.9″
+
+      expect(geometric.ecliptic.longitude.str(:dms))
+        .to eq("+149° 27′ 6.5779″")
+      # IMCCE:    +149° 27′ 6.571″
+      # Skyfield: +149° 27′ 17.0″
+
+      expect(geometric.distance.au)
+        .to eq(1.6665243265178227)
+      # IMCCE:    1.666524219608
+      # Skyfield: 1.66652432695766
     end
 
     it "computes the correct velocity" do
@@ -111,6 +126,16 @@ RSpec.describe Astronoby::Mars do
         .to eq("+24° 3′ 35.8686″")
       # IMCCE:    +24° 3′ 35.868″
       # Skyfield: +24° 3′ 35.9″
+
+      expect(astrometric.ecliptic.latitude.str(:dms))
+        .to eq("+2° 39′ 41.3343″")
+      # IMCCE:    +2° 39′ 41.334″
+      # Skyfield: +2° 39′ 51.8″
+
+      expect(astrometric.ecliptic.longitude.str(:dms))
+        .to eq("+113° 14′ 47.4513″")
+      # IMCCE:    +113° 14′ 47.455″
+      # Skyfield: +113° 35′ 57.8″
 
       expect(astrometric.distance.au)
         .to eq(1.138989231808293)

--- a/spec/astronoby/bodies/mercury_spec.rb
+++ b/spec/astronoby/bodies/mercury_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Astronoby::Mercury do
         .to eq("-6° 7′ 53.664″")
       # IMCCE:    -6° 7′ 53.680″
       # Skyfield: -6° 7′ 53.7″
+
+      expect(geometric.ecliptic.latitude.str(:dms))
+        .to eq("+3° 0′ 54.0574″")
+      # IMCCE:    +3° 0′ 54.055″
+      # Skyfield: +3° 0′ 48.5″
+
+      expect(geometric.ecliptic.longitude.str(:dms))
+        .to eq("+202° 58′ 41.4354″")
+      # IMCCE:    +202° 58′ 41.473″
+      # Skyfield: +202° 58′ 39.5″
+
+      expect(geometric.distance.au)
+        .to eq(0.4274945347661314)
+      # IMCCE:    0.427494398892
+      # Skyfield: 0.4274945451749377
     end
 
     it "computes the correct velocity" do
@@ -111,6 +126,16 @@ RSpec.describe Astronoby::Mercury do
         .to eq("-21° 54′ 45.5553″")
       # IMCCE:    -21° 54′ 45.557″
       # Skyfield: -21° 54′ 45.6″
+
+      expect(astrometric.ecliptic.latitude.str(:dms))
+        .to eq("+1° 7′ 0.4406″")
+      # IMCCE:    +1° 7′ 0.440″
+      # Skyfield: +1° 6′ 48.8″
+
+      expect(astrometric.ecliptic.longitude.str(:dms))
+        .to eq("+259° 31′ 33.854″")
+      # IMCCE:    +259° 31′ 33.864″
+      # Skyfield: +259° 52′ 31.4″
 
       expect(astrometric.distance.au)
         .to eq(1.1479011885933859)

--- a/spec/astronoby/bodies/neptune_spec.rb
+++ b/spec/astronoby/bodies/neptune_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Astronoby::Neptune do
         .to eq("-1° 11′ 21.2403″")
       # IMCCE:    -1° 11′ 21.197″
       # Skyfield: -1° 11′ 21.2″
+
+      expect(geometric.ecliptic.latitude.str(:dms))
+        .to eq("-1° 19′ 17.0443″")
+      # IMCCE:    -1° 19′ 17.013″
+      # Skyfield: -1° 19′ 16.0″
+
+      expect(geometric.ecliptic.longitude.str(:dms))
+        .to eq("+0° 3′ 29.1763″")
+      # IMCCE:    +0° 3′ 29.214″
+      # Skyfield: +0° 24′ 59.8″
+
+      expect(geometric.distance.au)
+        .to eq(29.884550201759172)
+      # IMCCE:    29.884551127591
+      # Skyfield: 29.88455020171849
     end
 
     it "computes the correct velocity" do
@@ -111,6 +126,16 @@ RSpec.describe Astronoby::Neptune do
         .to eq("-0° 35′ 37.2556″")
       # IMCCE:    -0° 35′ 37.211″
       # Skyfield: -0° 35′ 37.3″
+
+      expect(astrometric.ecliptic.latitude.str(:dms))
+        .to eq("-1° 20′ 58.8551″")
+      # IMCCE:    -1° 20′ 58.823″
+      # Skyfield: -1° 20′ 57.5″
+
+      expect(astrometric.ecliptic.longitude.str(:dms))
+        .to eq("+1° 37′ 15.5232″")
+      # IMCCE:    +1° 37′ 15.560″
+      # Skyfield: +1° 58′ 46.1″
 
       expect(astrometric.distance.au)
         .to eq(29.266429831403105)

--- a/spec/astronoby/bodies/saturn_spec.rb
+++ b/spec/astronoby/bodies/saturn_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Astronoby::Saturn do
         .to eq("-4° 13′ 34.4575″")
       # IMCCE:    -4° 13′ 34.458″
       # Skyfield: -4° 13′ 34.5″
+
+      expect(geometric.ecliptic.latitude.str(:dms))
+        .to eq("-2° 10′ 18.0315″")
+      # IMCCE:    -2° 10′ 18.032″
+      # Skyfield: -2° 10′ 18.1″
+
+      expect(geometric.ecliptic.longitude.str(:dms))
+        .to eq("+354° 22′ 47.1815″")
+      # IMCCE:    +354° 22′ 47.182″
+      # Skyfield: +354° 44′ 7.3″
+
+      expect(geometric.distance.au)
+        .to eq(9.580357829890923)
+      # IMCCE:    9.580357970998
+      # Skyfield: 9.580357829243903
     end
 
     it "computes the correct velocity" do
@@ -111,6 +126,16 @@ RSpec.describe Astronoby::Saturn do
         .to eq("-1° 52′ 50.7217″")
       # IMCCE:    -1° 52′ 50.722″
       # Skyfield: -1° 52′ 50.7″
+
+      expect(astrometric.ecliptic.latitude.str(:dms))
+        .to eq("-2° 6′ 26.3397″")
+      # IMCCE:    -2° 6′ 26.340″
+      # Skyfield: -2° 6′ 25.3″
+
+      expect(astrometric.ecliptic.longitude.str(:dms))
+        .to eq("+0° 7′ 56.1071″")
+      # IMCCE:    +0° 7′ 56.108″
+      # Skyfield: +0° 29′ 16.2″
 
       expect(astrometric.distance.au)
         .to eq(9.878564650795877)

--- a/spec/astronoby/bodies/uranus_spec.rb
+++ b/spec/astronoby/bodies/uranus_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Astronoby::Uranus do
         .to eq("+19° 22′ 35.4493″")
       # IMCCE:    +19° 22′ 35.421″
       # Skyfield: +19° 22′ 35.4″
+
+      expect(geometric.ecliptic.latitude.str(:dms))
+        .to eq("-0° 13′ 11.9158″")
+      # IMCCE:    -0° 13′ 11.922″
+      # Skyfield: -0° 13′ 1.3″
+
+      expect(geometric.ecliptic.longitude.str(:dms))
+        .to eq("+57° 27′ 4.2182″")
+      # IMCCE:    +57° 27′ 4.118″
+      # Skyfield: +57° 48′ 29.4″
+
+      expect(geometric.distance.au)
+        .to eq(19.515391974096183)
+      # IMCCE:    19.51539553769
+      # Skyfield: 19.51539197373322
     end
 
     it "computes the correct velocity" do
@@ -111,6 +126,16 @@ RSpec.describe Astronoby::Uranus do
         .to eq("+19° 48′ 18.8202″")
       # IMCCE:    +19° 48′ 18.795″
       # Skyfield: +19° 48′ 18.8″
+
+      expect(astrometric.ecliptic.latitude.str(:dms))
+        .to eq("-0° 12′ 43.8064″")
+      # IMCCE:    -0° 12′ 43.812″
+      # Skyfield: -0° 12′ 33.0″
+
+      expect(astrometric.ecliptic.longitude.str(:dms))
+        .to eq("+59° 21′ 17.3489″")
+      # IMCCE:    +59° 21′ 17.253″
+      # Skyfield: +59° 42′ 42.6″
 
       expect(astrometric.distance.au)
         .to eq(20.293374076651755)

--- a/spec/astronoby/bodies/venus_spec.rb
+++ b/spec/astronoby/bodies/venus_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Astronoby::Venus do
         .to eq("+24° 21′ 26.4794″")
       # IMCCE:    +24° 21′ 26.481″
       # Skyfield: +24° 21′ 26.5″
+
+      expect(geometric.ecliptic.latitude.str(:dms))
+        .to eq("+1° 25′ 43.096″")
+      # IMCCE:    +1° 25′ 43.095″
+      # Skyfield: +1° 25′ 54.4″
+
+      expect(geometric.ecliptic.longitude.str(:dms))
+        .to eq("+101° 35′ 6.7601″")
+      # IMCCE:    +101° 35′ 6.733″
+      # Skyfield: +101° 56′ 10.0″
+
+      expect(geometric.distance.au)
+        .to eq(0.7152904564103618)
+      # IMCCE:    0.715290459923
+      # Skyfield: 0.7152904566396294
     end
 
     it "computes the correct velocity" do
@@ -111,6 +126,16 @@ RSpec.describe Astronoby::Venus do
         .to eq("+0° 37′ 33.7021″")
       # IMCCE:    +0° 37′ 33.706″
       # Skyfield: +0° 37′ 33.7″
+
+      expect(astrometric.ecliptic.latitude.str(:dms))
+        .to eq("+1° 56′ 23.8202″")
+      # IMCCE:    +1° 56′ 23.821″
+      # Skyfield: +1° 56′ 24.3″
+
+      expect(astrometric.ecliptic.longitude.str(:dms))
+        .to eq("+357° 5′ 49.9018″")
+      # IMCCE:    +357° 5′ 49.909″
+      # Skyfield: +357° 26′ 52.6″
 
       expect(astrometric.distance.au)
         .to eq(0.5226080600832164)

--- a/spec/astronoby/coordinates/ecliptic_spec.rb
+++ b/spec/astronoby/coordinates/ecliptic_spec.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe Astronoby::Coordinates::Ecliptic do
+  describe "::zero" do
+    it "returns a new instance with zero angles" do
+      coordinates = described_class.zero
+
+      expect(coordinates.latitude).to eq(Astronoby::Angle.zero)
+      expect(coordinates.longitude).to eq(Astronoby::Angle.zero)
+    end
+  end
+
   describe "#to_true_equatorial" do
     # Source:
     #  Title: Celestial Calculations


### PR DESCRIPTION
Ecliptic coordinates already existed in Astronoby, but now we're making them available from `Geometric` and `Astrometric` reference frames.

In Astronoby, ecliptic coordinates are either barycentric (for `Geometric` reference frame) or geocentric (for `Astrometric` reference frame), with reference of the ecliptic plane, using the mean equinox of the standard epoch J2000. Please note that the chosen equninox will be different when we'll introduce the `Apparent` reference frame in the future (true equinox of date).

Please note as well that in the same way the Earth's astrometric equatorial coordinates are null because the astrometric position is geocentric, the Earth's astrometric ecliptic coordinates are also null.

```rb
instant = Astronoby::Instant.from_time(Time.utc(2025, 5, 1))
ephem = Astronoby::Ephem.load("de440s.bsp")

jupiter = Astronoby::Jupiter.new(instant: instant, ephem: ephem)

jupiter.geometric.ecliptic.latitude.str(:dms)
# => "-0° 16′ 22.9896″"

jupiter.geometric.ecliptic.longitude.str(:dms)
# => "+88° 24′ 41.3024″"

jupiter.astrometric.ecliptic.latitude.str(:dms)
# => "-0° 14′ 27.7664″"

jupiter.astrometric.ecliptic.longitude.str(:dms)
# => "+81° 1′ 11.959″"
```