### PR TITLE
Precession matrix for 2006 P03 model

### DIFF
--- a/lib/astronoby/angle.rb
+++ b/lib/astronoby/angle.rb
@@ -22,6 +22,10 @@ module Astronoby
         from_radians(radians)
       end
 
+      def from_degree_arcseconds(arcseconds)
+        from_dms(0, 0, arcseconds)
+      end
+
       def from_hours(hours)
         radians = hours * Constants::RADIAN_PER_HOUR
         from_radians(radians)

--- a/spec/astronoby/angle_spec.rb
+++ b/spec/astronoby/angle_spec.rb
@@ -50,6 +50,26 @@ RSpec.describe Astronoby::Angle do
     end
   end
 
+  describe "::from_degree_arcseconds" do
+    it "returns an Angle object" do
+      expect(described_class.from_degree_arcseconds(3600))
+        .to be_a(described_class)
+    end
+
+    it "normalizes the angle" do
+      expect(described_class.from_degree_arcseconds(3600).degrees.round(10))
+        .to eq 1
+      expect(described_class.from_degree_arcseconds(36).degrees.round(10))
+        .to eq 0.01
+      expect(described_class.from_degree_arcseconds(-3600).degrees.round(10))
+        .to eq(-1)
+      expect(described_class.from_degree_arcseconds(1299600).degrees.round(10))
+        .to eq(1)
+      expect(described_class.from_degree_arcseconds(-1299600).degrees.round(10))
+        .to eq(-1)
+    end
+  end
+
   describe "::from_hours" do
     it "returns an Angle object" do
       expect(described_class.from_hours(23)).to be_a(described_class)

--- a/spec/astronoby/precession_spec.rb
+++ b/spec/astronoby/precession_spec.rb
@@ -107,4 +107,44 @@ RSpec.describe Astronoby::Precession do
       )
     end
   end
+
+  describe "#matrix" do
+    it "returns the right matrix for 2025-08-01" do
+      time = Time.utc(2025, 8, 1)
+      instant = Astronoby::Instant.from_time(time)
+
+      matrix = described_class.new(instant).matrix
+
+      expect(matrix).to eq(
+        Matrix[
+          [0.9999805493402671, -0.00572043918489605, -0.002485461057708681],
+          [0.0057204392635234564, 0.999983638128416, -7.077398710142457e-06],
+          [0.002485460876742937, -7.140667972360681e-06, 0.9999969112118503]]
+      )
+      # Skyfield: [
+      #   [ 0.999980549   -0.00572043919 -0.00248546106]
+      #   [ 0.00572043926  0.999983638   -7.07739871e-06]
+      #   [ 0.00248546088 -7.14066798e-06 0.999996911]
+      # ]
+    end
+
+    it "returns the right matrix for 2050-01-01" do
+      time = Time.utc(2050, 1, 1)
+      instant = Astronoby::Instant.from_time(time)
+
+      matrix = described_class.new(instant).matrix
+
+      expect(matrix).to eq(
+        Matrix[
+          [0.9999256847034389, -0.011181602311713876, -0.004857657882310543],
+          [0.011181602603764246, 0.9999374835602728, -2.7099087538506872e-05],
+          [0.004857657210054194, -2.7219326363292495e-05, 0.9999882011431624]]
+      )
+      # Skyfield: [
+      #   [ 0.999925685   -0.0111816023   -0.00485765788]
+      #   [ 0.0111816026   0.999937484    -2.70990875e-05]
+      #   [ 0.00485765721 -2.72193264e-05  0.999988201]
+      # ]
+    end
+  end
 end


### PR DESCRIPTION
This enables to generate a rotation matrix to apply the 2006 P03 astronomical model for precession.

Also called "precession of equinoxes", precession is a change of the orientation of the Earth's rotational axis. It is a large but slow shift of the rotation axis which changes the direction of the celestial poles.