### PR TITLE
Improve Vector integration with value objects

### DIFF
--- a/lib/astronoby/aberration2.rb
+++ b/lib/astronoby/aberration2.rb
@@ -11,7 +11,7 @@ module Astronoby
     #  Edition: University Science Books
     #  Chapter: 7.2.3 - Aberration
 
-    LIGHT_SPEED = Astronoby::Velocity.light_speed.aupd
+    LIGHT_SPEED = Astronoby::Velocity.light_speed.mps
 
     # Initializes the aberration correction with position and observer velocity.
     #
@@ -22,8 +22,8 @@ module Astronoby
     def initialize(astrometric_position:, observer_velocity:)
       @position = astrometric_position
       @velocity = observer_velocity
-      @distance_au = @position.map(&:au).norm
-      @observer_speed = @velocity.map(&:aupd).norm
+      @distance_meters = @position.norm.m
+      @observer_speed = @velocity.norm.mps
     end
 
     # Computes the aberration-corrected position.
@@ -36,11 +36,11 @@ module Astronoby
       lorentz_factor_inv = lorentz_factor_inverse(beta)
 
       velocity_correction =
-        velocity_correction_factor(projected_velocity) * velocity_aupd
+        velocity_correction_factor(projected_velocity) * velocity_mps
       normalization_factor = 1.0 + projected_velocity
-      position_scaled = position_au * lorentz_factor_inv
+      position_scaled = position_meters * lorentz_factor_inv
 
-      to_position_vector(
+      Distance.vector_from_meters(
         (position_scaled + velocity_correction) / normalization_factor
       )
     end
@@ -48,16 +48,16 @@ module Astronoby
     private
 
     def aberration_angle_cos
-      denominator = [@distance_au * @observer_speed, 1e-20].max
-      Util::Maths.dot_product(position_au, velocity_aupd) / denominator
+      denominator = [@distance_meters * @observer_speed, 1e-20].max
+      Util::Maths.dot_product(position_meters, velocity_mps) / denominator
     end
 
-    def position_au
-      @position.map(&:au)
+    def position_meters
+      @position.map(&:meters)
     end
 
-    def velocity_aupd
-      @velocity.map(&:aupd)
+    def velocity_mps
+      @velocity.map(&:mps)
     end
 
     def lorentz_factor_inverse(beta)
@@ -66,11 +66,7 @@ module Astronoby
 
     def velocity_correction_factor(projected_velocity)
       lorentz_inv = lorentz_factor_inverse(projected_velocity)
-      (1.0 + projected_velocity / (1.0 + lorentz_inv)) * (@distance_au / LIGHT_SPEED)
-    end
-
-    def to_position_vector(vector)
-      Astronoby::Vector[*vector.map { |v| Astronoby::Distance.from_au(v) }]
+      (1.0 + projected_velocity / (1.0 + lorentz_inv)) * (@distance_meters / LIGHT_SPEED)
     end
   end
 end

--- a/lib/astronoby/coordinates/equatorial.rb
+++ b/lib/astronoby/coordinates/equatorial.rb
@@ -25,7 +25,7 @@ module Astronoby
         return zero if position.zero?
 
         term1 = position.z.m
-        term2 = position.magnitude
+        term2 = position.magnitude.m
         declination = Angle.asin(term1 / term2)
 
         term1 = position.y.m

--- a/lib/astronoby/distance.rb
+++ b/lib/astronoby/distance.rb
@@ -25,6 +25,11 @@ module Astronoby
         from_meters(meters)
       end
       alias_method :from_au, :from_astronomical_units
+
+      def vector_from_meters(array)
+        Vector.elements(array.map { from_meters(_1) })
+      end
+      alias_method :vector_from_m, :vector_from_meters
     end
 
     attr_reader :meters

--- a/lib/astronoby/observer.rb
+++ b/lib/astronoby/observer.rb
@@ -44,12 +44,11 @@ module Astronoby
 
     def geocentric_position
       n = earth_prime_vertical_radius_of_curvature
-      x = (n + @elevation.km) * @latitude.cos * @longitude.cos
-      y = (n + @elevation.km) * @latitude.cos * @longitude.sin
-      z = (n * (1 - Constants::WGS84_ECCENTICITY_SQUARED) + @elevation.km) *
+      x = (n + @elevation.m) * @latitude.cos * @longitude.cos
+      y = (n + @elevation.m) * @latitude.cos * @longitude.sin
+      z = (n * (1 - Constants::WGS84_ECCENTICITY_SQUARED) + @elevation.m) *
         @latitude.sin
-      # TODO: This is getting annoying, we need a class method on Vector
-      Vector.elements([x, y, z].map { Distance.from_km(_1) })
+      Distance.vector_from_meters([x, y, z])
     end
 
     def geocentric_velocity
@@ -57,8 +56,7 @@ module Astronoby
       vx = -Constants::EARTH_ANGULAR_VELOCITY_RAD_PER_S * r * @longitude.sin
       vy = Constants::EARTH_ANGULAR_VELOCITY_RAD_PER_S * r * @longitude.cos
       vz = 0.0
-      # TODO: This is getting annoying, we need a class method on Vector
-      Vector.elements([vx, vy, vz].map { Velocity.from_kmps(_1) })
+      Velocity.vector_from_mps([vx, vy, vz])
     end
 
     def earth_fixed_rotation_matrix_for(instant)
@@ -135,7 +133,7 @@ module Astronoby
     end
 
     def earth_prime_vertical_radius_of_curvature
-      (Constants::WGS84_EARTH_EQUATORIAL_RADIUS_IN_METERS / 1000.0)./(
+      Constants::WGS84_EARTH_EQUATORIAL_RADIUS_IN_METERS./(
         Math.sqrt(
           1 -
             Constants::WGS84_ECCENTICITY_SQUARED * @latitude.sin * @latitude.sin
@@ -145,8 +143,8 @@ module Astronoby
 
     def projected_radius
       Math.sqrt(
-        geocentric_position.x.km * geocentric_position.x.km +
-          geocentric_position.y.km * geocentric_position.y.km
+        geocentric_position.x.m * geocentric_position.x.m +
+          geocentric_position.y.m * geocentric_position.y.m
       )
     end
   end

--- a/lib/astronoby/reference_frame.rb
+++ b/lib/astronoby/reference_frame.rb
@@ -42,7 +42,7 @@ module Astronoby
       @distance ||= begin
         return Distance.zero if @position.zero?
 
-        Astronoby::Distance.from_meters(@position.magnitude)
+        @position.magnitude
       end
     end
   end

--- a/lib/astronoby/reference_frames/apparent.rb
+++ b/lib/astronoby/reference_frames/apparent.rb
@@ -14,9 +14,9 @@ module Astronoby
       precession_matrix = Precession.matrix_for(instant)
       nutation_matrix = Nutation2.matrix_for(instant)
 
-      corrected_position = Vector
-        .elements(precession_matrix * nutation_matrix * position.map(&:m))
-        .map { Distance.from_meters(_1) }
+      corrected_position = Distance.vector_from_meters(
+        precession_matrix * nutation_matrix * position.map(&:m)
+      )
       corrected_position = Aberration2.new(
         astrometric_position: corrected_position,
         observer_velocity: earth_geometric.velocity
@@ -27,9 +27,9 @@ module Astronoby
       # time by not applying it, and we will investigate if the algorithm is
       # correct or if the deflection is indeed negligible.
 
-      corrected_velocity = Vector[
-        *precession_matrix * nutation_matrix * velocity.map(&:aupd)
-      ].map { Velocity.from_astronomical_units_per_day(_1) }
+      corrected_velocity = Velocity.vector_from_mps(
+        precession_matrix * nutation_matrix * velocity.map(&:mps)
+      )
 
       new(
         position: corrected_position,

--- a/lib/astronoby/reference_frames/mean_of_date.rb
+++ b/lib/astronoby/reference_frames/mean_of_date.rb
@@ -12,11 +12,12 @@ module Astronoby
       position = target_geometric.position - earth_geometric.position
       velocity = target_geometric.velocity - earth_geometric.velocity
       precession_matrix = Precession.matrix_for(instant)
-      corrected_position = Vector
-        .elements(precession_matrix * position.map(&:m))
-        .map { Distance.from_meters(_1) }
-      corrected_velocity = Vector[*precession_matrix * velocity
-        .map(&:aupd)].map { Velocity.from_astronomical_units_per_day(_1) }
+      corrected_position = Distance.vector_from_m(
+        precession_matrix * position.map(&:m)
+      )
+      corrected_velocity = Velocity.vector_from_mps(
+        precession_matrix * velocity.map(&:mps)
+      )
 
       new(
         position: corrected_position,

--- a/lib/astronoby/reference_frames/topocentric.rb
+++ b/lib/astronoby/reference_frames/topocentric.rb
@@ -10,13 +10,11 @@ module Astronoby
     )
       matrix = observer.earth_fixed_rotation_matrix_for(instant)
 
-      observer_position = Astronoby::Vector.elements(
-        (matrix * observer.geocentric_position.map(&:km))
-          .map { Astronoby::Distance.from_km(_1) }
+      observer_position = Distance.vector_from_meters(
+        matrix * observer.geocentric_position.map(&:m)
       )
-      observer_velocity = Astronoby::Vector.elements(
-        (matrix * observer.geocentric_velocity.map(&:kmps))
-          .map { Astronoby::Velocity.from_kmps(_1) }
+      observer_velocity = Velocity.vector_from_mps(
+        matrix * observer.geocentric_velocity.map(&:kmps)
       )
 
       position = apparent.position - observer_position

--- a/lib/astronoby/vector.rb
+++ b/lib/astronoby/vector.rb
@@ -20,5 +20,17 @@ module Astronoby
     def z
       self[2]
     end
+
+    def magnitude
+      if all? { _1.is_a?(Astronoby::Distance) }
+        Astronoby::Distance.new(super)
+      elsif all? { _1.is_a?(Astronoby::Velocity) }
+        Astronoby::Velocity.new(super)
+      else
+        super
+      end
+    end
+    alias_method :norm, :magnitude
+    alias_method :r, :magnitude
   end
 end

--- a/lib/astronoby/velocity.rb
+++ b/lib/astronoby/velocity.rb
@@ -33,6 +33,12 @@ module Astronoby
           Constants::ASTRONOMICAL_UNIT_IN_METERS / Constants::SECONDS_PER_DAY
         from_meters_per_second(meters_per_second)
       end
+      alias_method :from_aupd, :from_astronomical_units_per_day
+
+      def vector_from_meters_per_second(array)
+        Vector.elements(array.map { from_mps(_1) })
+      end
+      alias_method :vector_from_mps, :vector_from_meters_per_second
 
       def light_speed
         from_meters_per_second(Constants::LIGHT_SPEED_M_PER_S)
@@ -90,6 +96,10 @@ module Astronoby
 
     def zero?
       @meters_per_second.zero?
+    end
+
+    def abs2
+      @meters_per_second**2
     end
 
     def hash

--- a/spec/astronoby/bodies/moon_spec.rb
+++ b/spec/astronoby/bodies/moon_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Astronoby::Moon do
       # Note: apparent distance doesn't really make sense
       # Prefer astrometric.distance
       expect(apparent.distance.au)
-        .to eq(0.0024238110763862715)
+        .to eq(0.002423811076386272)
       # IMCCE:    0.002423811046
       # Skyfield: 0.002423811056514584
     end

--- a/spec/astronoby/bodies/uranus_spec.rb
+++ b/spec/astronoby/bodies/uranus_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Astronoby::Uranus do
       # Note: apparent distance doesn't really make sense
       # Prefer astrometric.distance
       expect(apparent.distance.au)
-        .to eq(20.29337407665176)
+        .to eq(20.293374076651755)
       # IMCCE:    20.293377161363
       # Skyfield: 20.29337405352995
     end

--- a/spec/astronoby/bodies/venus_spec.rb
+++ b/spec/astronoby/bodies/venus_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Astronoby::Venus do
       # Note: apparent distance doesn't really make sense
       # Prefer astrometric.distance
       expect(apparent.distance.au)
-        .to eq(0.5226080600832163)
+        .to eq(0.5226080600832161)
       # IMCCE:    0.522608040526
       # Skyfield: 0.522608044699388
     end

--- a/spec/astronoby/distance_spec.rb
+++ b/spec/astronoby/distance_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe Astronoby::Distance do
     end
   end
 
+  describe "::vector_from_meters" do
+    it "returns a Vector of Distance objects" do
+      vector = described_class.vector_from_meters([1, 2, 3])
+
+      expect(vector).to be_a(Astronoby::Vector)
+      expect(vector).to all(be_a(described_class))
+    end
+  end
+
   describe "#meters" do
     it "returns the distance value in meters" do
       meters = described_class.new(1).meters

--- a/spec/astronoby/vector_spec.rb
+++ b/spec/astronoby/vector_spec.rb
@@ -64,12 +64,44 @@ RSpec.describe Astronoby::Vector do
   end
 
   describe "#magnitude" do
-    it "calculates the magnitude correctly" do
-      vector = described_class[3, 4, 0]
+    context "when all elements are distances" do
+      it "returns the magnitude as a Distance object" do
+        vector = described_class[
+          Astronoby::Distance.from_meters(3),
+          Astronoby::Distance.from_meters(4),
+          Astronoby::Distance.zero
+        ]
 
-      result = vector.magnitude
+        result = vector.magnitude
 
-      expect(result).to eq(5)
+        expect(result).to be_a(Astronoby::Distance)
+        expect(result.meters).to eq(5)
+      end
+    end
+
+    context "when all elements are velocities" do
+      it "returns the magnitude as a Velocity object" do
+        vector = described_class[
+          Astronoby::Velocity.from_mps(3),
+          Astronoby::Velocity.from_mps(4),
+          Astronoby::Velocity.zero
+        ]
+
+        result = vector.magnitude
+
+        expect(result).to be_a(Astronoby::Velocity)
+        expect(result.meters_per_second).to eq(5)
+      end
+    end
+
+    context "when elements are not all distances or velocities" do
+      it "returns the magnitude of the vector's numerical values" do
+        vector = described_class[3, 4, 0]
+
+        result = vector.magnitude
+
+        expect(result).to eq(5)
+      end
     end
   end
 

--- a/spec/astronoby/velocity_spec.rb
+++ b/spec/astronoby/velocity_spec.rb
@@ -63,6 +63,15 @@ RSpec.describe Astronoby::Velocity do
     end
   end
 
+  describe "::vector_from_meters_per_second" do
+    it "returns a Vector of Velocity objects" do
+      vector = described_class.vector_from_meters_per_second([1, 2, 3])
+
+      expect(vector).to be_a(Astronoby::Vector)
+      expect(vector).to all(be_a(described_class))
+    end
+  end
+
   describe "::light_speed" do
     it "returns a Velocity object" do
       expect(described_class.light_speed).to be_a(described_class)
@@ -217,6 +226,12 @@ RSpec.describe Astronoby::Velocity do
 
     it "returns false when the velocity has a non-zero value" do
       expect(described_class.from_meters_per_second(1).zero?).to be false
+    end
+  end
+
+  describe "#abs2" do
+    it "returns the square of the velocity value" do
+      expect(described_class.from_mps(3).abs2).to eq 9
     end
   end
 


### PR DESCRIPTION
In Astronoby we have a custom `Astronoby::Vector` object that helps manipulating value objects while still benefiting from the native `Vector` Ruby API.

So far however the integration wasn't so great with the need to frequently and manually loop over arrays to transform them into vectors of value object.

This is now improved with the ability to create a vector of `Distance` or `Velocity` objects from an array in the specified unit.

So far, only distances in meters and velocities in meters per second are supported as they are the only unit necessary in the code base at the moment.

`#magnitude` is also improved to return `Distance` or `Velocity` object depending on what the vector is made of, without breaking the ability to compute the magnitude from a vector of standard numeric values.