### PR TITLE
Handle refracted topocentric horizontal coordinates

### DIFF
--- a/lib/astronoby/reference_frames/topocentric.rb
+++ b/lib/astronoby/reference_frames/topocentric.rb
@@ -56,11 +56,17 @@ module Astronoby
       end
     end
 
-    def horizontal
-      @horizontal ||= equatorial.to_horizontal(
+    def horizontal(refraction: false)
+      horizontal = equatorial.to_horizontal(
         time: @instant.to_time,
         observer: @observer
       )
+
+      if refraction
+        Refraction.correct_horizontal_coordinates(coordinates: horizontal)
+      else
+        horizontal
+      end
     end
   end
 end

--- a/spec/astronoby/bodies/moon_spec.rb
+++ b/spec/astronoby/bodies/moon_spec.rb
@@ -360,6 +360,36 @@ RSpec.describe Astronoby::Moon do
         # Skyfield:   -2° 44′ 22.9″
       end
     end
+
+    context "with refraction" do
+      it "computes the correct position" do
+        time = Time.utc(2025, 3, 1, 12)
+        instant = Astronoby::Instant.from_time(time)
+        ephem = test_ephem
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(1.364917),
+          longitude: Astronoby::Angle.from_degrees(103.822872)
+        )
+        planet = described_class.new(instant: instant, ephem: ephem)
+
+        topocentric = planet.observed_by(observer)
+        horizontal = topocentric.horizontal(refraction: true)
+
+        aggregate_failures do
+          expect(horizontal.azimuth.str(:dms))
+            .to eq("+270° 40′ 43.3759″")
+          # Horizons:   +270° 40′ 41.7498″
+          # Stellarium: +270° 40′ 42.5″
+          # Skyfield:   +270° 40′ 41.7″
+
+          expect(horizontal.altitude.str(:dms))
+            .to eq("+6° 50′ 17.8399″")
+          # Horizons:   +6° 50′ 19.33″
+          # Stellarium: +6° 50′ 0.2″
+          # Skyfield:   +6° 50′ 15.7″
+        end
+      end
+    end
   end
 
   describe "::monthly_phase_events" do

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -360,6 +360,36 @@ RSpec.describe Astronoby::Sun do
         # Skyfield:   +16° 16′ 19.2″
       end
     end
+
+    context "with refraction" do
+      it "computes the correct position" do
+        time = Time.utc(2025, 10, 1)
+        instant = Astronoby::Instant.from_time(time)
+        ephem = test_ephem
+        observer = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(1.364917),
+          longitude: Astronoby::Angle.from_degrees(103.822872)
+        )
+        planet = described_class.new(instant: instant, ephem: ephem)
+
+        topocentric = planet.observed_by(observer)
+        horizontal = topocentric.horizontal(refraction: true)
+
+        aggregate_failures do
+          expect(horizontal.azimuth.str(:dms))
+            .to eq("+93° 44′ 19.9902″")
+          # Horizons:   +93° 44′ 20.1644″
+          # Stellarium: +93° 44′ 20.2″
+          # Skyfield:   +93° 44′ 20.2″
+
+          expect(horizontal.altitude.str(:dms))
+            .to eq("+16° 19′ 34.9175″")
+          # Horizons:   +16° 19′ 42.1874″
+          # Stellarium: +16° 19′ 39.8″
+          # Skyfield:   +16° 19′ 39.3″
+        end
+      end
+    end
   end
 
   describe "#true_ecliptic_coordinates" do


### PR DESCRIPTION
By default, the topocentric `horizontal` coordinates are computed in a theoretical air-less world, the position of an object in the sky as seen from an observer if the atmosphere had no impact.

But the atmosphere does have an impact, called the atmospheric refraction.

This enables to compute the horizontal coordinates using the `refraction` keyword (set to `false` by default) to compute the refracted coordinates.