### PR TITLE
Add `#angular_diameter` to apparent and topocentric reference frames

### DIFF
--- a/lib/astronoby/bodies/jupiter.rb
+++ b/lib/astronoby/bodies/jupiter.rb
@@ -2,6 +2,8 @@
 
 module Astronoby
   class Jupiter < SolarSystemBody
+    EQUATORIAL_RADIUS = Distance.from_meters(71_492_000)
+
     def self.ephemeris_segments
       [[SOLAR_SYSTEM_BARYCENTER, JUPITER_BARYCENTER]]
     end

--- a/lib/astronoby/bodies/mars.rb
+++ b/lib/astronoby/bodies/mars.rb
@@ -2,6 +2,8 @@
 
 module Astronoby
   class Mars < SolarSystemBody
+    EQUATORIAL_RADIUS = Distance.from_meters(3_396_200)
+
     def self.ephemeris_segments
       [[SOLAR_SYSTEM_BARYCENTER, MARS_BARYCENTER]]
     end

--- a/lib/astronoby/bodies/mercury.rb
+++ b/lib/astronoby/bodies/mercury.rb
@@ -2,6 +2,8 @@
 
 module Astronoby
   class Mercury < SolarSystemBody
+    EQUATORIAL_RADIUS = Distance.from_meters(2_439_700)
+
     def self.ephemeris_segments
       [[SOLAR_SYSTEM_BARYCENTER, MERCURY_BARYCENTER]]
     end

--- a/lib/astronoby/bodies/moon.rb
+++ b/lib/astronoby/bodies/moon.rb
@@ -4,6 +4,7 @@ module Astronoby
   class Moon < SolarSystemBody
     SEMIDIAMETER_VARIATION = 0.7275
     MEAN_GEOCENTRIC_DISTANCE = Astronoby::Distance.from_meters(385_000_560)
+    EQUATORIAL_RADIUS = Distance.from_meters(1_737_400)
 
     def self.ephemeris_segments
       [

--- a/lib/astronoby/bodies/neptune.rb
+++ b/lib/astronoby/bodies/neptune.rb
@@ -2,6 +2,8 @@
 
 module Astronoby
   class Neptune < SolarSystemBody
+    EQUATORIAL_RADIUS = Distance.from_meters(24_764_000)
+
     def self.ephemeris_segments
       [[SOLAR_SYSTEM_BARYCENTER, NEPTUNE_BARYCENTER]]
     end

--- a/lib/astronoby/bodies/saturn.rb
+++ b/lib/astronoby/bodies/saturn.rb
@@ -2,6 +2,8 @@
 
 module Astronoby
   class Saturn < SolarSystemBody
+    EQUATORIAL_RADIUS = Distance.from_meters(60_268_000)
+
     def self.ephemeris_segments
       [[SOLAR_SYSTEM_BARYCENTER, SATURN_BARYCENTER]]
     end

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -5,6 +5,7 @@ module Astronoby
     SEMI_MAJOR_AXIS_IN_METERS = 149_598_500_000
     ANGULAR_DIAMETER = Angle.from_degrees(0.533128)
     INTERPOLATION_FACTOR = 24.07
+    EQUATORIAL_RADIUS = Distance.from_meters(695_700_000)
 
     TWILIGHTS = [
       CIVIL = :civil,

--- a/lib/astronoby/bodies/uranus.rb
+++ b/lib/astronoby/bodies/uranus.rb
@@ -2,6 +2,8 @@
 
 module Astronoby
   class Uranus < SolarSystemBody
+    EQUATORIAL_RADIUS = Distance.from_meters(25_559_000)
+
     def self.ephemeris_segments
       [[SOLAR_SYSTEM_BARYCENTER, URANUS_BARYCENTER]]
     end

--- a/lib/astronoby/bodies/venus.rb
+++ b/lib/astronoby/bodies/venus.rb
@@ -2,6 +2,8 @@
 
 module Astronoby
   class Venus < SolarSystemBody
+    EQUATORIAL_RADIUS = Distance.from_meters(6_051_800)
+
     def self.ephemeris_segments
       [[SOLAR_SYSTEM_BARYCENTER, VENUS_BARYCENTER]]
     end

--- a/lib/astronoby/reference_frames/apparent.rb
+++ b/lib/astronoby/reference_frames/apparent.rb
@@ -47,5 +47,15 @@ module Astronoby
         equatorial.to_ecliptic(epoch: @instant.tdb)
       end
     end
+
+    def angular_diameter
+      @angular_radius ||= begin
+        return Angle.zero if @position.zero?
+
+        Angle.from_radians(
+          Math.atan(@target_body.class::EQUATORIAL_RADIUS.m / distance.m) * 2
+        )
+      end
+    end
   end
 end

--- a/lib/astronoby/reference_frames/topocentric.rb
+++ b/lib/astronoby/reference_frames/topocentric.rb
@@ -48,6 +48,16 @@ module Astronoby
       @observer = observer
     end
 
+    def angular_diameter
+      @angular_radius ||= begin
+        return Angle.zero if @position.zero?
+
+        Angle.from_radians(
+          Math.atan(@target_body.class::EQUATORIAL_RADIUS.m / distance.m) * 2
+        )
+      end
+    end
+
     def ecliptic
       @ecliptic ||= begin
         return Coordinates::Ecliptic.zero if distance.zero?

--- a/spec/astronoby/bodies/jupiter_spec.rb
+++ b/spec/astronoby/bodies/jupiter_spec.rb
@@ -358,6 +358,13 @@ RSpec.describe Astronoby::Jupiter do
         # Skyfield:   -10° 11′ 49.2″
         # Stellarium: -10° 11′ 48.8″
         # Horizons:   -10° 11′ 49.2716″
+
+        expect(topocentric.angular_diameter.str(:dms))
+          .to eq("+0° 0′ 33.7133″")
+        # IMCCE:      +0° 0′ 33.7133″
+        # Horizons:   +0° 0′ 33.7131″
+        # Stellarium: +0° 0′ 33.72″
+        # Skyfield:   +0° 0′ 33.7″
       end
     end
   end

--- a/spec/astronoby/bodies/mars_spec.rb
+++ b/spec/astronoby/bodies/mars_spec.rb
@@ -358,6 +358,13 @@ RSpec.describe Astronoby::Mars do
         # Horizons:   +26° 51′ 15.3662″
         # Stellarium: +26° 51′ 15.9″
         # Skyfield:   +26° 51′ 15.6″
+
+        expect(topocentric.angular_diameter.str(:dms))
+          .to eq("+0° 0′ 8.2226″")
+        # IMCCE:      +0° 0′ 8.2226″
+        # Horizons:   +0° 0′ 8.2223″
+        # Stellarium: +0° 0′ 8.22″
+        # Skyfield:   +0° 0′ 8.2″
       end
     end
   end

--- a/spec/astronoby/bodies/mercury_spec.rb
+++ b/spec/astronoby/bodies/mercury_spec.rb
@@ -358,6 +358,13 @@ RSpec.describe Astronoby::Mercury do
         # Horizons:   -56° 56′ 38.8135″
         # Stellarium: -56° 56′ 39.5″
         # Skyfield:   -56° 56′ 39.1″
+
+        expect(topocentric.angular_diameter.str(:dms))
+          .to eq("+0° 0′ 5.8606″")
+        # IMCCE:      +0° 0′ 5.8626″
+        # Horizons:   +0° 0′ 5.8627″
+        # Stellarium: +0° 0′ 5.8686″
+        # Skyfield:   +0° 0′ 5.9″
       end
     end
   end

--- a/spec/astronoby/bodies/moon_spec.rb
+++ b/spec/astronoby/bodies/moon_spec.rb
@@ -358,6 +358,13 @@ RSpec.describe Astronoby::Moon do
         # Horizons:   -2° 44′ 22.8363″
         # Stellarium: -2° 44′ 24.6″
         # Skyfield:   -2° 44′ 22.9″
+
+        expect(topocentric.angular_diameter.str(:dms))
+          .to eq("+0° 32′ 55.4816″")
+        # IMCCE:      +0° 32′ 55.3033″
+        # Horizons:   +0° 32′ 55.303″
+        # Stellarium: +0° 32′ 55.33″
+        # Skyfield:   +0° 32′ 55″
       end
     end
 

--- a/spec/astronoby/bodies/neptune_spec.rb
+++ b/spec/astronoby/bodies/neptune_spec.rb
@@ -358,6 +358,13 @@ RSpec.describe Astronoby::Neptune do
         # Horizons:   +24° 33′ 48.7809″
         # Stellarium: +24° 33′ 48.0″
         # Skyfield:   +24° 33′ 48.3″
+
+        expect(topocentric.angular_diameter.str(:dms))
+          .to eq("+0° 0′ 2.3333″")
+        # IMCCE:      +0° 0′ 2.3333″
+        # Horizons:   +0° 0′ 2.3333″
+        # Stellarium: +0° 0′ 2.33″
+        # Skyfield:   +0° 0′ 2.3″
       end
     end
   end

--- a/spec/astronoby/bodies/saturn_spec.rb
+++ b/spec/astronoby/bodies/saturn_spec.rb
@@ -358,6 +358,13 @@ RSpec.describe Astronoby::Saturn do
         # Horizons:   -13° 50′ 7.7396″
         # Stellarium: -13° 50′ 8.6″
         # Skyfield:   -13° 50′ 7.9″
+
+        expect(topocentric.angular_diameter.str(:dms))
+          .to eq("+0° 0′ 16.8237″")
+        # IMCCE:      +0° 0′ 16.8237″
+        # Horizons:   +0° 0′ 16.8237″
+        # Stellarium: +0° 0′ 16.82″
+        # Skyfield:   +0° 0′ 16.8″
       end
     end
   end

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -387,6 +387,13 @@ RSpec.describe Astronoby::Sun do
           # Horizons:   +16° 19′ 42.1874″
           # Stellarium: +16° 19′ 39.8″
           # Skyfield:   +16° 19′ 39.3″
+
+          expect(topocentric.angular_diameter.str(:dms))
+            .to eq("+0° 31′ 56.0484″")
+          # IMCCE:      +0° 31′ 56.0686″
+          # Horizons:   +0° 31′ 56.0689″
+          # Stellarium: +0° 31′ 56.04″
+          # Skyfield:   +0° 31′ 56.1″
         end
       end
     end

--- a/spec/astronoby/bodies/uranus_spec.rb
+++ b/spec/astronoby/bodies/uranus_spec.rb
@@ -358,6 +358,13 @@ RSpec.describe Astronoby::Uranus do
         # Horizons:   +51° 34′ 45.1039″
         # Stellarium: +51° 34′ 46.0″
         # Skyfield:   +51° 34′ 45.4″
+
+        expect(topocentric.angular_diameter.str(:dms))
+          .to eq("+0° 0′ 3.4731″")
+        # IMCCE:      +0° 0′ 3.4731″
+        # Horizons:   +0° 0′ 3.4731″
+        # Stellarium: +0° 0′ 3.47″
+        # Skyfield:   +0° 0′ 3.5″
       end
     end
   end

--- a/spec/astronoby/bodies/venus_spec.rb
+++ b/spec/astronoby/bodies/venus_spec.rb
@@ -358,6 +358,13 @@ RSpec.describe Astronoby::Venus do
         # Horizons:   -31° 34′ 29.5386″
         # Stellarium: -31° 34′ 30.5″
         # Skyfield:   -31° 34′ 29.6″
+
+        expect(topocentric.angular_diameter.str(:dms))
+          .to eq("+0° 0′ 31.9315″")
+        # IMCCE:      +0° 0′ 31.9315″
+        # Horizons:   +0° 0′ 31.9315″
+        # Stellarium: +0° 0′ 31.93″
+        # Skyfield:   +0° 0′ 31.9″
       end
     end
   end


### PR DESCRIPTION
This adds the angular distance a celestial body covers in the sky from a geocentric or topocentric observer.

It is only available to these two reference frames, and only topocentric covers it with tests, for the sake of simplicity.