### PR TITLE
Fix dependency secutiry patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     diff-lcs (1.5.1)
     ephem (0.1.0)
       numo-narray (~> 0.9.2.1)
-    json (2.10.1)
+    json (2.10.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     matrix (0.4.2)


### PR DESCRIPTION
This fixes [GHSA-9m3q-rhmv-5q44](https://github.com/ruby/json/security/advisories/GHSA-9m3q-rhmv-5q44).