### PR TITLE
Lazy-load reference frames

### DIFF
--- a/lib/astronoby/bodies/moon.rb
+++ b/lib/astronoby/bodies/moon.rb
@@ -56,17 +56,17 @@ module Astronoby
         sun = Sun.new(instant: @instant, ephem: ephem)
         geocentric_elongation = Angle.acos(
           sun.apparent.equatorial.declination.sin *
-            @apparent.equatorial.declination.sin +
+            apparent.equatorial.declination.sin +
             sun.apparent.equatorial.declination.cos *
-              @apparent.equatorial.declination.cos *
+              apparent.equatorial.declination.cos *
               (
                 sun.apparent.equatorial.right_ascension -
-                  @apparent.equatorial.right_ascension
+                  apparent.equatorial.right_ascension
               ).cos
         )
 
         term1 = sun.astrometric.distance.km * geocentric_elongation.sin
-        term2 = @astrometric.distance.km -
+        term2 = astrometric.distance.km -
           sun.astrometric.distance.km * geocentric_elongation.cos
         angle = Angle.atan(term1 / term2)
         Astronoby::Util::Trigonometry

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -16,7 +16,7 @@ module Astronoby
 
     # @return [Integer] Equation of time in seconds
     def equation_of_time
-      right_ascension = @apparent.equatorial.right_ascension
+      right_ascension = apparent.equatorial.right_ascension
       t = (@instant.julian_date - Epoch::J2000) / Constants::DAYS_PER_JULIAN_MILLENIA
       l0 = (280.4664567 +
         360_007.6982779 * t +

--- a/lib/astronoby/reference_frames/apparent.rb
+++ b/lib/astronoby/reference_frames/apparent.rb
@@ -3,12 +3,11 @@
 module Astronoby
   class Apparent < ReferenceFrame
     def self.build_from_astrometric(
-      ephem:,
       instant:,
       target_astrometric:,
+      earth_geometric:,
       target_body:
     )
-      earth_geometric = Earth.geometric(ephem: ephem, instant: instant)
       position = target_astrometric.position
       velocity = target_astrometric.velocity
       precession_matrix = Precession.matrix_for(instant)

--- a/lib/astronoby/reference_frames/astrometric.rb
+++ b/lib/astronoby/reference_frames/astrometric.rb
@@ -3,21 +3,15 @@
 module Astronoby
   class Astrometric < ReferenceFrame
     def self.build_from_geometric(
-      ephem:,
       instant:,
-      target_geometric:,
+      earth_geometric:,
+      light_time_corrected_position:,
+      light_time_corrected_velocity:,
       target_body:
     )
-      earth_geometric = Earth.geometric(ephem: ephem, instant: instant)
-      corrected_position, corrected_velocity =
-        Correction::LightTimeDelay.compute(
-          center: earth_geometric,
-          target: target_geometric,
-          ephem: ephem
-        )
       new(
-        position: corrected_position - earth_geometric.position,
-        velocity: corrected_velocity - earth_geometric.velocity,
+        position: light_time_corrected_position - earth_geometric.position,
+        velocity: light_time_corrected_velocity - earth_geometric.velocity,
         instant: instant,
         center_identifier: SolarSystemBody::EARTH,
         target_body: target_body

--- a/lib/astronoby/reference_frames/mean_of_date.rb
+++ b/lib/astronoby/reference_frames/mean_of_date.rb
@@ -3,12 +3,11 @@
 module Astronoby
   class MeanOfDate < ReferenceFrame
     def self.build_from_geometric(
-      ephem:,
       instant:,
       target_geometric:,
+      earth_geometric:,
       target_body:
     )
-      earth_geometric = Earth.geometric(ephem: ephem, instant: instant)
       position = target_geometric.position - earth_geometric.position
       velocity = target_geometric.velocity - earth_geometric.velocity
       precession_matrix = Precession.matrix_for(instant)

--- a/spec/astronoby/reference_frames/astrometric_spec.rb
+++ b/spec/astronoby/reference_frames/astrometric_spec.rb
@@ -30,15 +30,12 @@ RSpec.describe Astronoby::Astrometric do
         instant: instant
       )
       allow(Astronoby::Earth).to receive(:geometric).and_return(earth_double)
-      allow(Astronoby::Correction::LightTimeDelay).to(
-        receive(:compute)
-          .and_return([geometric.position, geometric.velocity])
-      )
 
       astrometric = described_class.build_from_geometric(
-        ephem: ephem,
         instant: instant,
-        target_geometric: geometric,
+        earth_geometric: earth_double,
+        light_time_corrected_position: geometric.position,
+        light_time_corrected_velocity: geometric.velocity,
         target_body: Astronoby::Jupiter
       )
 
@@ -73,15 +70,12 @@ RSpec.describe Astronoby::Astrometric do
         instant: instant
       )
       allow(Astronoby::Earth).to receive(:geometric).and_return(earth_double)
-      allow(Astronoby::Correction::LightTimeDelay).to(
-        receive(:compute)
-          .and_return([geometric.position, geometric.velocity])
-      )
 
       astrometric = described_class.build_from_geometric(
-        ephem: ephem,
         instant: instant,
-        target_geometric: geometric,
+        earth_geometric: earth_double,
+        light_time_corrected_position: geometric.position,
+        light_time_corrected_velocity: geometric.velocity,
         target_body: Astronoby::Jupiter
       )
 
@@ -112,7 +106,7 @@ RSpec.describe Astronoby::Astrometric do
       )
       segment = double(compute_and_differentiate: state)
       ephem = double(:[] => segment)
-      geometric = Astronoby::Jupiter.geometric(
+      Astronoby::Jupiter.geometric(
         ephem: ephem,
         instant: instant
       )
@@ -130,27 +124,23 @@ RSpec.describe Astronoby::Astrometric do
         ],
         instant: instant
       )
+      light_time_corrected_position = Astronoby::Vector[
+        Astronoby::Distance.from_km(50),
+        Astronoby::Distance.from_km(100),
+        Astronoby::Distance.from_km(150)
+      ]
+      light_time_corrected_velocity = Astronoby::Vector[
+        Astronoby::Velocity.from_mps(3),
+        Astronoby::Velocity.from_mps(6),
+        Astronoby::Velocity.from_mps(9)
+      ]
       allow(Astronoby::Earth).to receive(:geometric).and_return(earth_double)
-      allow(Astronoby::Correction::LightTimeDelay)
-        .to receive(:compute).and_return(
-          [
-            Astronoby::Vector[
-              Astronoby::Distance.from_km(50),
-              Astronoby::Distance.from_km(100),
-              Astronoby::Distance.from_km(150)
-            ],
-            Astronoby::Vector[
-              Astronoby::Velocity.from_mps(3),
-              Astronoby::Velocity.from_mps(6),
-              Astronoby::Velocity.from_mps(9)
-            ]
-          ]
-        )
 
       astrometric = described_class.build_from_geometric(
-        ephem: ephem,
         instant: instant,
-        target_geometric: geometric,
+        earth_geometric: earth_double,
+        light_time_corrected_position: light_time_corrected_position,
+        light_time_corrected_velocity: light_time_corrected_velocity,
         target_body: Astronoby::Jupiter
       )
 

--- a/spec/astronoby/reference_frames/mean_of_date_spec.rb
+++ b/spec/astronoby/reference_frames/mean_of_date_spec.rb
@@ -29,12 +29,11 @@ RSpec.describe Astronoby::MeanOfDate do
         ],
         instant: instant
       )
-      allow(Astronoby::Earth).to receive(:geometric).and_return(earth_double)
 
       mean_of_date = described_class.build_from_geometric(
-        ephem: ephem,
         instant: instant,
         target_geometric: geometric,
+        earth_geometric: earth_double,
         target_body: Astronoby::Jupiter
       )
 
@@ -68,15 +67,14 @@ RSpec.describe Astronoby::MeanOfDate do
         ],
         instant: instant
       )
-      allow(Astronoby::Earth).to receive(:geometric).and_return(earth_double)
       allow(Astronoby::Precession).to receive(:matrix_for).and_return(
         Matrix[[1, 0, 0], [0, 1, 0], [0, 0, 1]]
       )
 
       mean_of_date = described_class.build_from_geometric(
-        ephem: ephem,
         instant: instant,
         target_geometric: geometric,
+        earth_geometric: earth_double,
         target_body: Astronoby::Jupiter
       )
 


### PR DESCRIPTION
Before, `geometric`, `astrometric`, `mean_of_date` and `apparent` reference frames were computed immediately at the body's initialization. This was due to the fact that they all need at least some piece of information from other reference frames. This was also to make sure `ephem` was never saved as instance variable as it can be a very large one.

Now, only the required pieces of information are computed on initialization:
* `geometric` reference frame
* Earth's geometric position
* Light-time correction

From this data, `astrometric`, `mean_of_date` and `apparent` positions can be computed just-in-time. `ephem` is still not saved as instance variable as it is not necessary anymore once the required data is computed.

While this is not going to change much for parts of the library that use the apparent position as it requires `geometric` and `astrometric` to be computed, it is going to improve the overall performance of the library by preventing to compute all reference frames when they're not all necessary.