### PR TITLE
v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,121 @@
 # Changelog
 
+## 0.7.0 - 2025-05-12
+
+_If you are upgrading: please see [UPGRADING.md]._
+
+### Bug fixes
+
+* Fix Moon monthly phase events calculation by @valeriy-sokoloff in ([#124])
+
+### Features
+
+* Add `Instant` value object ([#121])
+* Introduce barycentric position of Solar System major bodies ([#127])
+* Introduce Astrometric position for planets ([#129])
+* Rename Barycentric into Geometric ([#130])
+* Rename IRCF and remove module Position ([#131])
+* Geometric and Astrometric reference frames with coordinates ([#132])
+* Ecliptic coordinates for Geometric and Astrometric reference frames ([#134])
+* Add Geometric and Astrometric positions for `Sun` and `Moon` ([#135])
+* Implement new aberration correction ([#136])
+* Precession matrix for 2006 P03 model ([#137])
+* Introduce `MeanOfDate` reference frame ([#138])
+* New nutation model ([#141])
+* Light deflection correction ([#142])
+* Introduce `Apparent` reference frame ([#143])
+* Introduce `Topocentric` reference frame ([#145])
+* Improve Vector integration with value objects ([#146])
+* Handle refracted topocentric horizontal coordinates ([#147])
+* Add `#angular_diameter` to apparent and topocentric reference frames ([#149])
+* Introduce new calculator for rising, transit and setting times ([#148])
+* Clean code after Ephem refactoring ([#152])
+* Improve `RisingTransitSettingEventsCalculator` ([#155])
+* Simplify `RisingTransitSettingEventsCalculator` ([#156])
+* Lazy-load reference frames ([#157])
+* Overall performance improvements ([#163])
+* Add support for IMCCE INPOP by @JoelQ and @rhannequin ([#166])
+* Update INPOP excerpt in spec data ([#167])
+* Introduce a better rise/transit/set calculator ([#168])
+* Drop `Astronoby::Observer#observe` ([#174])
+
+### Improvements
+
+* Bump standard from 1.42.1 to 1.49.0 by @dependabot ([#123], [#128], [#150], [#165])
+* Bump rubyzip from 2.3.2 to 2.4.1 by @dependabot ([#120])
+* Add more tests for Julian Date conversion ([#122])
+* Upgrade main Ruby version and supported ones ([#125])
+* Update email address and gem description ([#126])
+* Increase precision of mean obliquity ([#133])
+* Add supported Rubies ([#139])
+* Set Ruby 3.4.2 as default version ([#140])
+* Fix dependency secutiry patch ([#151])
+* Improve HMS/DMS formats ([#153])
+* Use excerpts ephemerides for specs of Sun and Moon ([#154])
+* Add link to deprecated documentation ([#160])
+* Default Ruby 3.4.3 and support recent rubies ([#169])
+* Better Moon phases test coverage ([#172])
+* Optimize Observer with GMST from Instant ([#173])
+* Update README about documentation location ([#175])
+* Add GitHub Actions permissions ([#176])
+
+### New Contributors
+
+* @valeriy-sokoloff made their first contribution in https://github.com/rhannequin/astronoby/pull/124
+* @JoelQ made their first contribution in https://github.com/rhannequin/astronoby/pull/166
+
+**Full Changelog**: https://github.com/rhannequin/astronoby/compare/v0.6.0...v0.7.0
+
+[#120]: https://github.com/rhannequin/astronoby/pull/120
+[#121]: https://github.com/rhannequin/astronoby/pull/121
+[#122]: https://github.com/rhannequin/astronoby/pull/122
+[#123]: https://github.com/rhannequin/astronoby/pull/123
+[#124]: https://github.com/rhannequin/astronoby/pull/124
+[#125]: https://github.com/rhannequin/astronoby/pull/125
+[#126]: https://github.com/rhannequin/astronoby/pull/126
+[#127]: https://github.com/rhannequin/astronoby/pull/127
+[#128]: https://github.com/rhannequin/astronoby/pull/128
+[#129]: https://github.com/rhannequin/astronoby/pull/129
+[#130]: https://github.com/rhannequin/astronoby/pull/130
+[#131]: https://github.com/rhannequin/astronoby/pull/131
+[#132]: https://github.com/rhannequin/astronoby/pull/132
+[#133]: https://github.com/rhannequin/astronoby/pull/133
+[#134]: https://github.com/rhannequin/astronoby/pull/134
+[#135]: https://github.com/rhannequin/astronoby/pull/135
+[#136]: https://github.com/rhannequin/astronoby/pull/136
+[#137]: https://github.com/rhannequin/astronoby/pull/137
+[#138]: https://github.com/rhannequin/astronoby/pull/138
+[#139]: https://github.com/rhannequin/astronoby/pull/139
+[#140]: https://github.com/rhannequin/astronoby/pull/140
+[#141]: https://github.com/rhannequin/astronoby/pull/141
+[#142]: https://github.com/rhannequin/astronoby/pull/142
+[#143]: https://github.com/rhannequin/astronoby/pull/143
+[#145]: https://github.com/rhannequin/astronoby/pull/145
+[#146]: https://github.com/rhannequin/astronoby/pull/146
+[#147]: https://github.com/rhannequin/astronoby/pull/147
+[#148]: https://github.com/rhannequin/astronoby/pull/148
+[#149]: https://github.com/rhannequin/astronoby/pull/149
+[#150]: https://github.com/rhannequin/astronoby/pull/150
+[#151]: https://github.com/rhannequin/astronoby/pull/151
+[#152]: https://github.com/rhannequin/astronoby/pull/152
+[#153]: https://github.com/rhannequin/astronoby/pull/153
+[#154]: https://github.com/rhannequin/astronoby/pull/154
+[#155]: https://github.com/rhannequin/astronoby/pull/155
+[#156]: https://github.com/rhannequin/astronoby/pull/156
+[#157]: https://github.com/rhannequin/astronoby/pull/157
+[#160]: https://github.com/rhannequin/astronoby/pull/160
+[#163]: https://github.com/rhannequin/astronoby/pull/163
+[#165]: https://github.com/rhannequin/astronoby/pull/165
+[#166]: https://github.com/rhannequin/astronoby/pull/166
+[#167]: https://github.com/rhannequin/astronoby/pull/167
+[#168]: https://github.com/rhannequin/astronoby/pull/168
+[#169]: https://github.com/rhannequin/astronoby/pull/169
+[#172]: https://github.com/rhannequin/astronoby/pull/172
+[#173]: https://github.com/rhannequin/astronoby/pull/173
+[#174]: https://github.com/rhannequin/astronoby/pull/174
+[#175]: https://github.com/rhannequin/astronoby/pull/175
+[#176]: https://github.com/rhannequin/astronoby/pull/176
+
 ## 0.6.0 - 2024-12-10
 
 _If you are upgrading: please see [UPGRADING.md]._

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    astronoby (0.6.0)
-      ephem (~> 0.2)
+    astronoby (0.7.0)
+      ephem (~> 0.3)
       matrix (~> 0.4.2)
 
 GEM

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,6 +7,244 @@ changes to it as long as a major version has not been released.
 If you are already using Astronoby and wish to follow the changes to its
 public API, please read the upgrading notes for each release.
 
+## Upgrading from 0.6.0 to 0.7.0
+
+## Signature change for `Sun` and `Moon`
+
+Both classes are now initialized with the key arguments `ephem` and `instant`.
+`ephem` comes from `Ephem.load` which provides the raw geometric data for Solar
+System bodies. `instant` is an instance of `Instant`, the new concept for
+representing an instant in time.
+
+```rb
+Ephem::IO::Download.call(name: "de421.bsp", target: "tmp/de421.bsp")
+ephem = Astronoby::Ephem.load("tmp/de421.bsp")
+
+time = Time.utc(2025, 6, 19, 12, 0, 0)
+instant = Astronoby::Instant.from_time(time)
+
+sun = Astronoby::Sun.new(instant: instant, ephem: ephem)
+```
+
+Learn more on [ephem].
+
+[ephem]: https://github.com/rhannequin/astronoby/wiki/Ephem
+
+## Drop of methods for `Sun`
+
+`Sun` doesn't expose the following class and instance methods anymore:
+* `::equation_of_time` (replaced with `#equation_of_time`)
+* `#epoch` (replaced with `#instant`)
+* `#true_ecliptic_coordinates` (replaced with `#ecliptic` on reference frames)
+* `#apparent_ecliptic_coordinates` (replaced with `#ecliptic` on reference frames)
+* `#horizontal_coordinates` (replaced with `#horizontal` on the Topocentric reference frame)
+* `#observation_events`
+* `#twilight_events`
+* `#earth_distance` (replaced with `#distance` on referential frames)
+* `#angular_size` (replaced with `#angular_diameter` on referential frames)
+* `#true_anomaly`
+* `#mean_anomaly`
+* `#longitude_at_perigee`
+* `#orbital_eccentricity`
+
+Learn more on [reference frames].
+
+[reference frames]: https://github.com/rhannequin/astronoby/wiki/Reference-Frames
+
+## Drop of instance methods for `Moon`
+
+`Moon` doesn't expose the following nstance methods anymore:
+* `#apparent_ecliptic_coordinates` (replaced with `#ecliptic` on reference frames)
+* `#apparent_equatorial_coordinates` (replaced with `#equatorial` on reference frames)
+* `#horizontal_coordinates` (replaced with the Apparent and Topocentric reference frames)
+* `#distance` (replaced with `#distance` on referential frames)
+* `#mean_longitude`
+* `#mean_elongation`
+* `#mean_anomaly`
+* `#argument_of_latitude`
+* `#phase_angle`
+* `#observation_events`
+
+## Signature change for `Aberration`
+
+`Aberration` is now initialized with the key arguments `astrometric_position`
+and `observer_velocity`. `astrometric_position` is a position vector
+(`Astronoby::Vector<Astronoby::Distance>`) available from any referential frame
+with the `#position` method.`observer_velocity` is a velocity vector
+(`Astronoby::Vector<Astronoby::Distance>`) available from any referential frame
+with the `#velocity` method.
+
+`observer_velocity` is meant to be a geometric velocity, while
+`astrometric_position` is meant to be an astrometric position.
+
+```rb
+time = Time.utc(2025, 4, 1)
+instant = Astronoby::Instant.from_time(time)
+ephem = Astronoby::Ephem.load("de421.bsp")
+earth = Astronoby::Earth.new(instant: instant, ephem: ephem)
+mars = Astronoby::Mars.new(instant: instant, ephem: ephem)
+earth_geometric_velocity = earth.geometric.velocity
+mars_astrometric_position = mars.astrometric.position
+
+aberration = Astronoby::Aberration.new(
+  astrometric_position: mars_astrometric_position,
+  observer_velocity: earth_geometric_velocity
+)
+```
+
+## Signature change for `Angle#to_dms` and `Angle#to_hms`
+
+`Angle#to_dms` and `Angle#to_hms` don't have arguments anymore. The angle value
+is now taken from the object itself. This was a misbehavior in the previous
+implementation.
+
+```rb
+angle = Astronoby::Angle.from_degrees(45.0)
+dms = angle.to_dms
+
+dms.format
+# => "+45° 0′ 0.0″"
+```
+
+## Signature change for `EquinoxSolstice`
+
+`EquinoxSolstice.new` now takes an additional argument expected to be an ephem
+(`Astronoby::Ephem`).
+
+## Signature change for `Nutation`
+
+The expected `epoch` (`Astronoby::Epoch`) argument has been replaced by an
+`instant` (`Astronoby::Instant`) key argument.
+
+## Drop of `Nutation::for_ecliptic_longitude` and `Nutation::for_obliquity_of_the_ecliptic`
+
+`Nutation::for_ecliptic_longitude` and `Nutation::for_obliquity_of_the_ecliptic`
+methods have been removed. The `Nutation` class now exposes the
+`#nutation_in_longitude` and `#nutation_in_obliquity` instance methods which 
+both return an angle (`Astronoby::Angle`).
+
+## Signature change for `Precession`
+
+The expected `coordinates` and `epoch` (`Astronoby::Epoch`) key arguments have
+been replaced by an `instant` (`Astronoby::Instant`) key argument.
+
+## Drop of `Precession#for_equatorial_coordinates` and `Precession#precess`
+
+`Precession#for_equatorial_coordinates` and `Precession#precess` methods have
+been refactoed into class methods.
+
+## Drop of `Coordinates::Horizontal#to_equatorial`
+
+`Coordinates::Horizontal#to_equatorial` has been removed as equatorial
+coordinates are now available from the reference frames.
+
+## Drop of instance methods for `Coordinates::Ecliptic`
+
+`Coordinates::Ecliptic#to_true_equatorial` and
+`Coordinates::Ecliptic#to_apparent_equatorial` have been removed as
+equatorial coordinates are now available from the reference frames.
+
+## Drop of `Coordinates::Equatorial#to_epoch`
+
+`Coordinates::Equatorial#to_epoch` has been removed.
+
+## Drop of `Events::ObservationEvents`
+
+`Events::ObservationEvents` has been removed. The rising, transit and setting 
+times can now be calculated using `RiseTransitSetCalculator`.
+
+```rb
+ephem = Astronoby::Ephem.load("inpop19a.bsp")
+observer = Astronoby::Observer.new(
+  latitude: Astronoby::Angle.from_degrees(48),
+  longitude: Astronoby::Angle.from_degrees(2)
+)
+date = Date.new(2025, 4, 24)
+
+calculator = Astronoby::RiseTransitSetCalculator.new(
+  body: Astronoby::Sun,
+  observer: observer,
+  ephem: ephem
+)
+
+event = calculator.event_on(date)
+
+event.rising_time
+# => 2025-04-24 04:45:42 UTC
+
+event.transit_time
+# => 2025-04-24 11:50:04 UTC
+
+event.setting_time
+# => 2025-04-24 18:55:24 UTC
+```
+
+## Drop of `RiseTransitSetIteration`
+
+`RiseTransitSetIteration` has been removed as it was only used by
+`Events::ObservationEvents`.
+
+## Drop of `Events::TwilightEvents`
+
+`Events::TwilightEvents` has been removed. The twilight times can now be
+calculated using `TwilightCalculator`.
+
+```rb
+ephem = Astronoby::Ephem.load("inpop19a.bsp")
+observer = Astronoby::Observer.new(
+  latitude: Astronoby::Angle.from_degrees(48),
+  longitude: Astronoby::Angle.from_degrees(2)
+)
+date = Date.new(2025, 4, 24)
+
+calculator = Astronoby::TwilightCalculator.new(
+  observer: observer,
+  ephem: ephem
+)
+
+event = calculator.event_on(date)
+# Returns a Astronoby::TwilightEvent object
+
+event.morning_astronomical_twilight_time
+# => 2025-04-24 02:43:38 UTC
+
+event.morning_nautical_twilight_time
+# => 2025-04-24 03:30:45 UTC
+
+event.morning_civil_twilight_time
+# => 2025-04-24 04:12:38 UTC
+
+event.evening_civil_twilight_time
+# => 2025-04-24 19:27:34 UTC
+
+event.evening_nautical_twilight_time
+# => 2025-04-24 20:09:27 UTC
+
+event.evening_astronomical_twilight_time
+# => 2025-04-24 20:56:34 UTC
+```
+
+## Drop of `EphemerideLunaireParisienne`
+
+`EphemerideLunaireParisienne` has been removed.
+
+## Drop of `Util::Astrodynamics`
+
+`Util::Astrodynamics` has been removed.
+
+## Drop of `Util::Maths.interpolate` and `Util::Maths.normalize_angles_for_interpolation`
+
+`Util::Maths.interpolate` and `Util::Maths.normalize_angles_for_interpolation`
+have been removed.
+
+## Drop of `Constants::SECONDS_PER_DEGREE`
+
+`Constants::SECONDS_PER_DEGREE` has been removed.
+
+## Upgrading from 0.5.0 to 0.6.0
+
+No breaking changes.
+
 ## Upgrading from 0.4.0 to 0.5.0
 
 ### `Sun#horizontal_coordinates` method signature changed ([#69])

--- a/astronoby.gemspec
+++ b/astronoby.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ephem", "~> 0.2"
+  spec.add_dependency "ephem", "~> 0.3"
   spec.add_dependency "matrix", "~> 0.4.2"
 
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/astronoby/version.rb
+++ b/lib/astronoby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Astronoby
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end


### PR DESCRIPTION
## 0.7.0 - 2025-05-12

_If you are upgrading: please see [UPGRADING.md]._

### Bug fixes

* Fix Moon monthly phase events calculation by @valeriy-sokoloff in ([#124])

### Features

* Add `Instant` value object ([#121])
* Introduce barycentric position of Solar System major bodies ([#127])
* Introduce Astrometric position for planets ([#129])
* Rename Barycentric into Geometric ([#130])
* Rename IRCF and remove module Position ([#131])
* Geometric and Astrometric reference frames with coordinates ([#132])
* Ecliptic coordinates for Geometric and Astrometric reference frames ([#134])
* Add Geometric and Astrometric positions for `Sun` and `Moon` ([#135])
* Implement new aberration correction ([#136])
* Precession matrix for 2006 P03 model ([#137])
* Introduce `MeanOfDate` reference frame ([#138])
* New nutation model ([#141])
* Light deflection correction ([#142])
* Introduce `Apparent` reference frame ([#143])
* Introduce `Topocentric` reference frame ([#145])
* Improve Vector integration with value objects ([#146])
* Handle refracted topocentric horizontal coordinates ([#147])
* Add `#angular_diameter` to apparent and topocentric reference frames ([#149])
* Introduce new calculator for rising, transit and setting times ([#148])
* Clean code after Ephem refactoring ([#152])
* Improve `RisingTransitSettingEventsCalculator` ([#155])
* Simplify `RisingTransitSettingEventsCalculator` ([#156])
* Lazy-load reference frames ([#157])
* Overall performance improvements ([#163])
* Add support for IMCCE INPOP by @JoelQ and @rhannequin ([#166])
* Update INPOP excerpt in spec data ([#167])
* Introduce a better rise/transit/set calculator ([#168])
* Drop `Astronoby::Observer#observe` ([#174])

### Improvements

* Bump standard from 1.42.1 to 1.49.0 by @dependabot ([#123], [#128], [#150], [#165])
* Bump rubyzip from 2.3.2 to 2.4.1 by @dependabot ([#120])
* Add more tests for Julian Date conversion ([#122])
* Upgrade main Ruby version and supported ones ([#125])
* Update email address and gem description ([#126])
* Increase precision of mean obliquity ([#133])
* Add supported Rubies ([#139])
* Set Ruby 3.4.2 as default version ([#140])
* Fix dependency secutiry patch ([#151])
* Improve HMS/DMS formats ([#153])
* Use excerpts ephemerides for specs of Sun and Moon ([#154])
* Add link to deprecated documentation ([#160])
* Default Ruby 3.4.3 and support recent rubies ([#169])
* Better Moon phases test coverage ([#172])
* Optimize Observer with GMST from Instant ([#173])
* Update README about documentation location ([#175])
* Add GitHub Actions permissions ([#176])

### New Contributors

* @valeriy-sokoloff made their first contribution in https://github.com/rhannequin/astronoby/pull/124
* @JoelQ made their first contribution in https://github.com/rhannequin/astronoby/pull/166

**Full Changelog**: https://github.com/rhannequin/astronoby/compare/v0.6.0...v0.7.0

[#120]: https://github.com/rhannequin/astronoby/pull/120
[#121]: https://github.com/rhannequin/astronoby/pull/121
[#122]: https://github.com/rhannequin/astronoby/pull/122
[#123]: https://github.com/rhannequin/astronoby/pull/123
[#124]: https://github.com/rhannequin/astronoby/pull/124
[#125]: https://github.com/rhannequin/astronoby/pull/125
[#126]: https://github.com/rhannequin/astronoby/pull/126
[#127]: https://github.com/rhannequin/astronoby/pull/127
[#128]: https://github.com/rhannequin/astronoby/pull/128
[#129]: https://github.com/rhannequin/astronoby/pull/129
[#130]: https://github.com/rhannequin/astronoby/pull/130
[#131]: https://github.com/rhannequin/astronoby/pull/131
[#132]: https://github.com/rhannequin/astronoby/pull/132
[#133]: https://github.com/rhannequin/astronoby/pull/133
[#134]: https://github.com/rhannequin/astronoby/pull/134
[#135]: https://github.com/rhannequin/astronoby/pull/135
[#136]: https://github.com/rhannequin/astronoby/pull/136
[#137]: https://github.com/rhannequin/astronoby/pull/137
[#138]: https://github.com/rhannequin/astronoby/pull/138
[#139]: https://github.com/rhannequin/astronoby/pull/139
[#140]: https://github.com/rhannequin/astronoby/pull/140
[#141]: https://github.com/rhannequin/astronoby/pull/141
[#142]: https://github.com/rhannequin/astronoby/pull/142
[#143]: https://github.com/rhannequin/astronoby/pull/143
[#145]: https://github.com/rhannequin/astronoby/pull/145
[#146]: https://github.com/rhannequin/astronoby/pull/146
[#147]: https://github.com/rhannequin/astronoby/pull/147
[#148]: https://github.com/rhannequin/astronoby/pull/148
[#149]: https://github.com/rhannequin/astronoby/pull/149
[#150]: https://github.com/rhannequin/astronoby/pull/150
[#151]: https://github.com/rhannequin/astronoby/pull/151
[#152]: https://github.com/rhannequin/astronoby/pull/152
[#153]: https://github.com/rhannequin/astronoby/pull/153
[#154]: https://github.com/rhannequin/astronoby/pull/154
[#155]: https://github.com/rhannequin/astronoby/pull/155
[#156]: https://github.com/rhannequin/astronoby/pull/156
[#157]: https://github.com/rhannequin/astronoby/pull/157
[#160]: https://github.com/rhannequin/astronoby/pull/160
[#163]: https://github.com/rhannequin/astronoby/pull/163
[#165]: https://github.com/rhannequin/astronoby/pull/165
[#166]: https://github.com/rhannequin/astronoby/pull/166
[#167]: https://github.com/rhannequin/astronoby/pull/167
[#168]: https://github.com/rhannequin/astronoby/pull/168
[#169]: https://github.com/rhannequin/astronoby/pull/169
[#172]: https://github.com/rhannequin/astronoby/pull/172
[#173]: https://github.com/rhannequin/astronoby/pull/173
[#174]: https://github.com/rhannequin/astronoby/pull/174
[#175]: https://github.com/rhannequin/astronoby/pull/175
[#176]: https://github.com/rhannequin/astronoby/pull/176
[UPGRADING.md]: https://github.com/rhannequin/astronoby/blob/main/UPGRADING.md