### PR TITLE
Drop `Astronoby::Observer#observe`

### DIFF
--- a/lib/astronoby/observer.rb
+++ b/lib/astronoby/observer.rb
@@ -85,10 +85,6 @@ module Astronoby
       earth_rotation_matrix * nutation_matrix * precession_matrix
     end
 
-    def observe(celestial_body)
-      celestial_body.observed_by(self)
-    end
-
     def ==(other)
       return false unless other.is_a?(self.class)
 


### PR DESCRIPTION
`#observe` was in fact broken as it computes a topocentric position from an apparent one, but the method doesn't have what is needed for computed an apparent position.

The method could be fixed, but because the same result could be obtained using `Astronoby::SolarSystemBody#observed_by` I don't see it necessary to have two methods in the end.