### PR TITLE
Cache positions in RTS calculator

### DIFF
--- a/lib/astronoby/events/rise_transit_set_calculator.rb
+++ b/lib/astronoby/events/rise_transit_set_calculator.rb
@@ -268,8 +268,9 @@ module Astronoby
     end
 
     def calculate_positions_at_instants(instants)
+      @positions_cache ||= {}
       instants.map do |instant|
-        @body
+        @positions_cache[instant] ||= @body
           .new(instant: instant, ephem: @ephem)
           .observed_by(@observer)
       end
@@ -347,6 +348,7 @@ module Astronoby
       @sample_instants = nil
       @start_instant = nil
       @end_instant = nil
+      @positions_cache = nil
     end
   end
 end


### PR DESCRIPTION
When computing the rise, transit and set times of a celestial body, the position of the body could be computed multiple times for the same instant. This is not optimized, especially while computing a position is one of the most expensive operation of the library, as we speak.

This caches the computed position during a single operation (`event_on`, ...).

### Comparison

In order to make sure the change has a real impact on performance, I wrote a simplistic benchmark and followed the "measure twice, cut once" guideline by running it on `main` and running it on this branch.

#### Code

```rb
ephem = Astronoby::Ephem.load("spec/support/data/inpop19a_2025_excerpt.bsp")
observer = Astronoby::Observer.new(
  latitude: Astronoby::Angle.zero,
  longitude: Astronoby::Angle.zero
)
start_full_time = Time.now
duration_event_on = 0
duration_events_between = 0
10.times do
  [
    Astronoby::Mercury,
    Astronoby::Venus,
    Astronoby::Mars,
    Astronoby::Jupiter,
    Astronoby::Saturn,
    Astronoby::Uranus,
    Astronoby::Neptune,
  ].each do |planet|
    calculator = Astronoby::RiseTransitSetCalculator.new(
      body: planet,
      observer: observer,
      ephem: ephem
    )
    time_start = Time.now
    (Date.new(2025, 5, 1)..Date.new(2025, 6, 1)).to_a.each do |date|
      calculator.event_on(date)
    end
    duration_event_on += Time.now - time_start
    time_start = Time.now
    calculator.events_between(Time.utc(2025, 7, 1), Time.utc(2025, 8, 1))
    duration_events_between += Time.now - time_start
  end
end
end_full_time = Time.now
puts "Duration event_on: #{duration_event_on.round(2)} seconds"
puts "Duration events_between: #{duration_events_between.round(2)} seconds"
puts "Duration full time: #{(end_full_time - start_full_time).round(2)} seconds"
```

#### Results

##### Initial

```
Duration event_on: 26.56 seconds
Duration events_between: 22.15 seconds
Duration full time: 48.72 seconds
```

##### Fixed

```
Duration event_on: 17.79 seconds
Duration events_between: 13.69 seconds
Duration full time: 31.47 seconds
```

#### Conclusion

We can estimate a performance improvement between 33% and 38%.