### PR TITLE
Fix possible division by zero in RTS

### DIFF
--- a/lib/astronoby/events/rise_transit_set_calculator.rb
+++ b/lib/astronoby/events/rise_transit_set_calculator.rb
@@ -237,13 +237,14 @@ module Astronoby
         )
 
         # Calculate time differences
-        time_differences = new_instants.each_with_index.map do |instant, i|
-          Instant.from_terrestrial_time(instant.tt - old_instants[i].tt)
+        time_differences_in_days = new_instants.each_with_index.map do |instant, i|
+          instant.tt - old_instants[i].tt
         end
 
         # Calculate hour angle rate (radians per day)
         hour_angle_rates = hour_angle_changes.each_with_index.map do |angle, i|
-          angle.radians / time_differences[i].tt
+          denominator = time_differences_in_days[i]
+          angle.radians / denominator
         end
 
         # Store current values for next iteration
@@ -255,7 +256,8 @@ module Astronoby
           .each_with_index
           .map do |angle, i|
             ratio = angle.radians / hour_angle_rates[i]
-            [ratio.nan? ? 0 : ratio, MIN_TIME_ADJUSTMENT].max
+            time_adjustment = (ratio.nan? || ratio.infinite?) ? 0 : ratio
+            [time_adjustment, MIN_TIME_ADJUSTMENT].max
           end
 
         # Apply time adjustments


### PR DESCRIPTION
Before, in `RiseTransitSetCalculator`, when calculating refined time estimates, there were two issues, now fixed:
* the time difference wasn't properly set, there were instants instead of durations
* the time adjustments could be `Infinty` if the hour angle rate was zero