### PR TITLE
v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,89 @@
 # Changelog
 
+## 0.8.0 - 2025-09-01
+
+_If you are upgrading: please see [UPGRADING.md]._
+
+### Bug fixes
+
+* Fix UPGRADING documentation ([#178])
+* Fix possible division by zero in RTS ([#185])
+
+### Features
+
+* Introduce performance benchmark ([#183])
+* Cache positions in RTS calculator ([#182])
+* Internal global LRU cache ([#186])
+* Global configuration ([#187])
+* Compute the constellation a body is in ([#199])
+* Add `#phase_angle` and `#illuminated_fraction` to planets ([#200])
+* Apparent magnitude ([#201])
+* Add #events_between to TwilightCalculator with better accuracy ([#204])
+* `#angular_diameter` on Solar System bodies ([#207])
+* Fix constellation boundaries near 24h right ascension ([#209])
+
+### Improvements
+
+* Bump standard from 1.49.0 to 1.50.0 by @dependabot ([#177])
+* Bump ephem from 0.3.0 to 0.4.1 by @dependabot ([#181], [#191])
+* Bump irb from 1.14.3 to 1.15.2 by @dependabot ([#184])
+* Bump rspec from 3.13.0 to 3.13.1 by @dependabot ([#188])
+* Bump benchmark from 0.4.0 to 0.4.1 by @dependabot ([#189])
+* Bump rake from 13.2.1 to 13.3.0 by @dependabot ([#190])
+* Bump matrix from 0.4.2 to 0.4.3 by @dependabot ([#193])
+* Update rubyzip requirement from ~> 2.3 to ~> 3.0 by @dependabot ([#194])
+* Bump rubyzip from 3.0.0 to 3.0.2 by @dependabot ([#202], [#206])
+* Exclude benchmarks from release ([#196])
+* `Epoch` refactoring into `JulianDate` ([#197])
+* Support Ruby 3.4.4 ([#198])
+* Bump actions/checkout from 4 to 5 ([#203])
+* Internal documentation ([#205])
+
+### Backward-incompatible changes
+
+* `Epoch` refactoring into `JulianDate` ([#197])
+* `#angular_diameter` on Solar System bodies ([#207])
+* Rename "epoch" ([#208])
+
+### Closed issues
+
+* Consider adding typical usage/deployment info ([#179])
+* Performance degradation in v0.7 ([#180])
+
+**Full Changelog**: https://github.com/rhannequin/astronoby/compare/v0.7.0...v0.8.0
+
+[#177]: https://github.com/rhannequin/astronoby/pull/177
+[#178]: https://github.com/rhannequin/astronoby/pull/178
+[#179]: https://github.com/rhannequin/astronoby/pull/179
+[#180]: https://github.com/rhannequin/astronoby/pull/180
+[#181]: https://github.com/rhannequin/astronoby/pull/181
+[#182]: https://github.com/rhannequin/astronoby/pull/182
+[#183]: https://github.com/rhannequin/astronoby/pull/183
+[#184]: https://github.com/rhannequin/astronoby/pull/184
+[#185]: https://github.com/rhannequin/astronoby/pull/185
+[#186]: https://github.com/rhannequin/astronoby/pull/186
+[#187]: https://github.com/rhannequin/astronoby/pull/187
+[#188]: https://github.com/rhannequin/astronoby/pull/188
+[#189]: https://github.com/rhannequin/astronoby/pull/189
+[#190]: https://github.com/rhannequin/astronoby/pull/190
+[#191]: https://github.com/rhannequin/astronoby/pull/191
+[#193]: https://github.com/rhannequin/astronoby/pull/193
+[#194]: https://github.com/rhannequin/astronoby/pull/194
+[#196]: https://github.com/rhannequin/astronoby/pull/196
+[#197]: https://github.com/rhannequin/astronoby/pull/197
+[#198]: https://github.com/rhannequin/astronoby/pull/198
+[#199]: https://github.com/rhannequin/astronoby/pull/199
+[#200]: https://github.com/rhannequin/astronoby/pull/200
+[#201]: https://github.com/rhannequin/astronoby/pull/201
+[#202]: https://github.com/rhannequin/astronoby/pull/202
+[#203]: https://github.com/rhannequin/astronoby/pull/203
+[#204]: https://github.com/rhannequin/astronoby/pull/204
+[#205]: https://github.com/rhannequin/astronoby/pull/205
+[#206]: https://github.com/rhannequin/astronoby/pull/206
+[#207]: https://github.com/rhannequin/astronoby/pull/207
+[#208]: https://github.com/rhannequin/astronoby/pull/208
+[#209]: https://github.com/rhannequin/astronoby/pull/209
+
 ## 0.7.0 - 2025-05-12
 
 _If you are upgrading: please see [UPGRADING.md]._
@@ -296,7 +380,7 @@ _If you are upgrading: please see [UPGRADING.md]._
 
 ## 0.3.0 - 2024-03-29
 
-_If you are upgrading: please see [`UPGRADING.md`]._
+_If you are upgrading: please see [UPGRADING.md]._
 
 ### Improvements
 
@@ -315,7 +399,7 @@ _If you are upgrading: please see [`UPGRADING.md`]._
 
 ## 0.2.0 - 2024-03-24
 
-_If you are upgrading: please see [`UPGRADING.md`]._
+_If you are upgrading: please see [UPGRADING.md]._
 
 ### Features
 
@@ -386,4 +470,4 @@ _If you are upgrading: please see [`UPGRADING.md`]._
 * Add `Astronoby::Angle`
 * Support angles in degrees and radians
 
-[`UPGRADING.md`]: https://github.com/rhannequin/astronoby/blob/main/UPGRADING.md
+[UPGRADING.md]: https://github.com/rhannequin/astronoby/blob/main/UPGRADING.md

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    astronoby (0.7.0)
+    astronoby (0.8.0)
       ephem (~> 0.3)
       matrix (~> 0.4.2)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,9 +7,38 @@ changes to it as long as a major version has not been released.
 If you are already using Astronoby and wish to follow the changes to its
 public API, please read the upgrading notes for each release.
 
+## Upgrading from 0.7.0 to 0.8.0
+
+### Benchmark directory changed
+
+The precision benchmark has been moved to `benchmarks`.
+
+### `Epoch` refactored into `JulianDate`
+
+The `Epoch` class has been removed and replaced by `JulianDate`. This change is
+meant to clarify the purpose of the class, which is to represent a Julian date
+and not an epoch.
+
+* Method `#to_utc` has been dropped in favor as is was ambiguous regarding the
+  timescale used.
+* Therefore, constant `JULIAN_DAY_NUMBER_OFFSET` has also been dropped.
+* `MeanObliquity::for_epoch` was renamed to `::at` and now takes an `instant` as
+  parameter
+* `MeanObliquity::obliquity_of_reference_in_milliarcseconds` was renamed to
+  `::obliquity_of_reference_in_arcseconds`
+* `TrueObliquity::for_epoch` was renamed to to `::at` and now takes an
+  `instant` as parameter
+* `Coordinates::Equatorial#to_ecliptic` method now takes an `instant` as
+  parameter
+
+### `#angular_diameter` moved from topocentric position to body
+
+Previously accessible from the topocentric reference frame, the angular diameter
+of a Solar System body is now accessible from the body itself.
+
 ## Upgrading from 0.6.0 to 0.7.0
 
-## Signature change for `Sun` and `Moon`
+### Signature change for `Sun` and `Moon`
 
 Both classes are now initialized with the key arguments `ephem` and `instant`.
 `ephem` comes from `Ephem.load` which provides the raw geometric data for Solar
@@ -30,7 +59,7 @@ Learn more on [ephem].
 
 [ephem]: https://github.com/rhannequin/astronoby/wiki/Ephem
 
-## Drop of methods for `Sun`
+### Drop of methods for `Sun`
 
 `Sun` doesn't expose the following class and instance methods anymore:
 * `::equation_of_time` (replaced with `#equation_of_time`)
@@ -51,7 +80,7 @@ Learn more on [reference frames].
 
 [reference frames]: https://github.com/rhannequin/astronoby/wiki/Reference-Frames
 
-## Drop of instance methods for `Moon`
+### Drop of instance methods for `Moon`
 
 `Moon` doesn't expose the following nstance methods anymore:
 * `#apparent_ecliptic_coordinates` (replaced with `#ecliptic` on reference frames)
@@ -65,7 +94,7 @@ Learn more on [reference frames].
 * `#phase_angle`
 * `#observation_events`
 
-## Signature change for `Aberration`
+### Signature change for `Aberration`
 
 `Aberration` is now initialized with the key arguments `astrometric_position`
 and `observer_velocity`. `astrometric_position` is a position vector
@@ -92,7 +121,7 @@ aberration = Astronoby::Aberration.new(
 )
 ```
 
-## Signature change for `Angle#to_dms` and `Angle#to_hms`
+### Signature change for `Angle#to_dms` and `Angle#to_hms`
 
 `Angle#to_dms` and `Angle#to_hms` don't have arguments anymore. The angle value
 is now taken from the object itself. This was a misbehavior in the previous
@@ -106,49 +135,49 @@ dms.format
 # => "+45° 0′ 0.0″"
 ```
 
-## Signature change for `EquinoxSolstice`
+### Signature change for `EquinoxSolstice`
 
 `EquinoxSolstice.new` now takes an additional argument expected to be an ephem
 (`Astronoby::Ephem`).
 
-## Signature change for `Nutation`
+### Signature change for `Nutation`
 
 The expected `epoch` (`Astronoby::Epoch`) argument has been replaced by an
 `instant` (`Astronoby::Instant`) key argument.
 
-## Drop of `Nutation::for_ecliptic_longitude` and `Nutation::for_obliquity_of_the_ecliptic`
+### Drop of `Nutation::for_ecliptic_longitude` and `Nutation::for_obliquity_of_the_ecliptic`
 
 `Nutation::for_ecliptic_longitude` and `Nutation::for_obliquity_of_the_ecliptic`
 methods have been removed. The `Nutation` class now exposes the
 `#nutation_in_longitude` and `#nutation_in_obliquity` instance methods which 
 both return an angle (`Astronoby::Angle`).
 
-## Signature change for `Precession`
+### Signature change for `Precession`
 
 The expected `coordinates` and `epoch` (`Astronoby::Epoch`) key arguments have
 been replaced by an `instant` (`Astronoby::Instant`) key argument.
 
-## Drop of `Precession#for_equatorial_coordinates` and `Precession#precess`
+### Drop of `Precession#for_equatorial_coordinates` and `Precession#precess`
 
 `Precession#for_equatorial_coordinates` and `Precession#precess` methods have
 been refactoed into class methods.
 
-## Drop of `Coordinates::Horizontal#to_equatorial`
+### Drop of `Coordinates::Horizontal#to_equatorial`
 
 `Coordinates::Horizontal#to_equatorial` has been removed as equatorial
 coordinates are now available from the reference frames.
 
-## Drop of instance methods for `Coordinates::Ecliptic`
+### Drop of instance methods for `Coordinates::Ecliptic`
 
 `Coordinates::Ecliptic#to_true_equatorial` and
 `Coordinates::Ecliptic#to_apparent_equatorial` have been removed as
 equatorial coordinates are now available from the reference frames.
 
-## Drop of `Coordinates::Equatorial#to_epoch`
+### Drop of `Coordinates::Equatorial#to_epoch`
 
 `Coordinates::Equatorial#to_epoch` has been removed.
 
-## Drop of `Events::ObservationEvents`
+### Drop of `Events::ObservationEvents`
 
 `Events::ObservationEvents` has been removed. The rising, transit and setting 
 times can now be calculated using `RiseTransitSetCalculator`.
@@ -179,12 +208,12 @@ event.setting_time
 # => 2025-04-24 18:55:24 UTC
 ```
 
-## Drop of `RiseTransitSetIteration`
+### Drop of `RiseTransitSetIteration`
 
 `RiseTransitSetIteration` has been removed as it was only used by
 `Events::ObservationEvents`.
 
-## Drop of `Events::TwilightEvents`
+### Drop of `Events::TwilightEvents`
 
 `Events::TwilightEvents` has been removed. The twilight times can now be
 calculated using `TwilightCalculator`.
@@ -224,20 +253,20 @@ event.evening_astronomical_twilight_time
 # => 2025-04-24 20:56:34 UTC
 ```
 
-## Drop of `EphemerideLunaireParisienne`
+### Drop of `EphemerideLunaireParisienne`
 
 `EphemerideLunaireParisienne` has been removed.
 
-## Drop of `Util::Astrodynamics`
+### Drop of `Util::Astrodynamics`
 
 `Util::Astrodynamics` has been removed.
 
-## Drop of `Util::Maths.interpolate` and `Util::Maths.normalize_angles_for_interpolation`
+### Drop of `Util::Maths.interpolate` and `Util::Maths.normalize_angles_for_interpolation`
 
 `Util::Maths.interpolate` and `Util::Maths.normalize_angles_for_interpolation`
 have been removed.
 
-## Drop of `Constants::SECONDS_PER_DEGREE`
+### Drop of `Constants::SECONDS_PER_DEGREE`
 
 `Constants::SECONDS_PER_DEGREE` has been removed.
 

--- a/lib/astronoby/version.rb
+++ b/lib/astronoby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Astronoby
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
## 0.8.0 - 2025-09-01

_If you are upgrading: please see [UPGRADING.md]._

### Bug fixes

* Fix UPGRADING documentation ([#178])
* Fix possible division by zero in RTS ([#185])

### Features

* Introduce performance benchmark ([#183])
* Cache positions in RTS calculator ([#182])
* Internal global LRU cache ([#186])
* Global configuration ([#187])
* Compute the constellation a body is in ([#199])
* Add `#phase_angle` and `#illuminated_fraction` to planets ([#200])
* Apparent magnitude ([#201])
* Add #events_between to TwilightCalculator with better accuracy ([#204])
* `#angular_diameter` on Solar System bodies ([#207])
* Fix constellation boundaries near 24h right ascension ([#209])

### Improvements

* Bump standard from 1.49.0 to 1.50.0 by @dependabot ([#177])
* Bump ephem from 0.3.0 to 0.4.1 by @dependabot ([#181], [#191])
* Bump irb from 1.14.3 to 1.15.2 by @dependabot ([#184])
* Bump rspec from 3.13.0 to 3.13.1 by @dependabot ([#188])
* Bump benchmark from 0.4.0 to 0.4.1 by @dependabot ([#189])
* Bump rake from 13.2.1 to 13.3.0 by @dependabot ([#190])
* Bump matrix from 0.4.2 to 0.4.3 by @dependabot ([#193])
* Update rubyzip requirement from ~> 2.3 to ~> 3.0 by @dependabot ([#194])
* Bump rubyzip from 3.0.0 to 3.0.2 by @dependabot ([#202], [#206])
* Exclude benchmarks from release ([#196])
* `Epoch` refactoring into `JulianDate` ([#197])
* Support Ruby 3.4.4 ([#198])
* Bump actions/checkout from 4 to 5 ([#203])
* Internal documentation ([#205])

### Backward-incompatible changes

* `Epoch` refactoring into `JulianDate` ([#197])
* `#angular_diameter` on Solar System bodies ([#207])
* Rename "epoch" ([#208])

### Closed issues

* Consider adding typical usage/deployment info ([#179])
* Performance degradation in v0.7 ([#180])

**Full Changelog**: https://github.com/rhannequin/astronoby/compare/v0.7.0...v0.8.0

[#177]: https://github.com/rhannequin/astronoby/pull/177
[#178]: https://github.com/rhannequin/astronoby/pull/178
[#179]: https://github.com/rhannequin/astronoby/pull/179
[#180]: https://github.com/rhannequin/astronoby/pull/180
[#181]: https://github.com/rhannequin/astronoby/pull/181
[#182]: https://github.com/rhannequin/astronoby/pull/182
[#183]: https://github.com/rhannequin/astronoby/pull/183
[#184]: https://github.com/rhannequin/astronoby/pull/184
[#185]: https://github.com/rhannequin/astronoby/pull/185
[#186]: https://github.com/rhannequin/astronoby/pull/186
[#187]: https://github.com/rhannequin/astronoby/pull/187
[#188]: https://github.com/rhannequin/astronoby/pull/188
[#189]: https://github.com/rhannequin/astronoby/pull/189
[#190]: https://github.com/rhannequin/astronoby/pull/190
[#191]: https://github.com/rhannequin/astronoby/pull/191
[#193]: https://github.com/rhannequin/astronoby/pull/193
[#194]: https://github.com/rhannequin/astronoby/pull/194
[#196]: https://github.com/rhannequin/astronoby/pull/196
[#197]: https://github.com/rhannequin/astronoby/pull/197
[#198]: https://github.com/rhannequin/astronoby/pull/198
[#199]: https://github.com/rhannequin/astronoby/pull/199
[#200]: https://github.com/rhannequin/astronoby/pull/200
[#201]: https://github.com/rhannequin/astronoby/pull/201
[#202]: https://github.com/rhannequin/astronoby/pull/202
[#203]: https://github.com/rhannequin/astronoby/pull/203
[#204]: https://github.com/rhannequin/astronoby/pull/204
[#205]: https://github.com/rhannequin/astronoby/pull/205
[#206]: https://github.com/rhannequin/astronoby/pull/206
[#207]: https://github.com/rhannequin/astronoby/pull/207
[#208]: https://github.com/rhannequin/astronoby/pull/208
[#209]: https://github.com/rhannequin/astronoby/pull/209
[UPGRADING.md]: https://github.com/rhannequin/astronoby/blob/main/UPGRADING.md
