### PR TITLE
Exclude benchmarks from release

### DIFF
--- a/astronoby.gemspec
+++ b/astronoby.gemspec
@@ -19,10 +19,21 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(__dir__) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+  # The `git ls-files -z` loads the files in the RubyGem that have been added
+  # into git.
+  gemspec = File.basename(__FILE__)
+  spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
+    ls.readlines("\x0", chomp: true).reject do |f|
+      (f == gemspec) || f.start_with?(
+        *%w[
+          benchmarks/
+          bin/
+          spec/
+          .git
+          .github
+          Gemfile
+        ]
+      )
     end
   end
   spec.bindir = "exe"


### PR DESCRIPTION
This helps reducing the size of the gem when installed.

Inspired by this comment from @trevorturk: https://github.com/rhannequin/astronoby/issues/180#issuecomment-3146570980