### PR TITLE
Add `#phase_angle` and `#illuminated_fraction` to planets

### DIFF
--- a/lib/astronoby/bodies/earth.rb
+++ b/lib/astronoby/bodies/earth.rb
@@ -21,6 +21,7 @@ module Astronoby
 
     private
 
+    # Phase angle is geocentric, therefore non-applicable for Earth.
     def compute_phase_angle?
       false
     end

--- a/lib/astronoby/bodies/earth.rb
+++ b/lib/astronoby/bodies/earth.rb
@@ -15,9 +15,17 @@ module Astronoby
       end
     end
 
+    def phase_angle
+      nil
+    end
+
     private
 
-    def compute_astrometric(ephem)
+    def compute_phase_angle?
+      false
+    end
+
+    def compute_astrometric(_ephem)
       Astrometric.new(
         position: Vector[
           Distance.zero,
@@ -35,7 +43,7 @@ module Astronoby
       )
     end
 
-    def compute_mean_of_date(ephem)
+    def compute_mean_of_date(_ephem)
       MeanOfDate.new(
         position: Vector[
           Distance.zero,

--- a/lib/astronoby/bodies/moon.rb
+++ b/lib/astronoby/bodies/moon.rb
@@ -32,18 +32,6 @@ module Astronoby
       Events::MoonPhases.phases_for(year: year, month: month)
     end
 
-    attr_reader :phase_angle
-
-    def initialize(instant:, ephem:)
-      super
-      @phase_angle = compute_phase_angle(ephem)
-    end
-
-    # @return [Float] Moon's illuminated fraction
-    def illuminated_fraction
-      @illuminated_fraction ||= (1 + phase_angle.cos) / 2.0
-    end
-
     # @return [Float] Phase fraction, from 0 to 1
     def current_phase_fraction
       mean_elongation.degrees / Constants::DEGREES_PER_CIRCLE
@@ -56,31 +44,6 @@ module Astronoby
     #  Author: Jean Meeus
     #  Edition: 2nd edition
     #  Chapter: 48 - Illuminated Fraction of the Moon's Disk
-
-    # @return [Angle] Moon's phase angle
-    def compute_phase_angle(ephem)
-      @phase_angle ||= begin
-        sun = Sun.new(instant: @instant, ephem: ephem)
-        geocentric_elongation = Angle.acos(
-          sun.apparent.equatorial.declination.sin *
-            apparent.equatorial.declination.sin +
-            sun.apparent.equatorial.declination.cos *
-              apparent.equatorial.declination.cos *
-              (
-                sun.apparent.equatorial.right_ascension -
-                  apparent.equatorial.right_ascension
-              ).cos
-        )
-
-        term1 = sun.astrometric.distance.km * geocentric_elongation.sin
-        term2 = astrometric.distance.km -
-          sun.astrometric.distance.km * geocentric_elongation.cos
-        angle = Angle.atan(term1 / term2)
-        Astronoby::Util::Trigonometry
-          .adjustement_for_arctangent(term1, term2, angle)
-      end
-    end
-
     def mean_elongation
       @mean_elongation ||= Angle.from_degrees(
         (

--- a/lib/astronoby/bodies/solar_system_body.rb
+++ b/lib/astronoby/bodies/solar_system_body.rb
@@ -128,7 +128,8 @@ module Astronoby
       )
     end
 
-    # @return [Float, nil] Moon's illuminated fraction
+    # Fraction between 0 and 1 of the body's disk that is illuminated.
+    # @return [Float, nil] Body's illuminated fraction, between 0 and 1.
     def illuminated_fraction
       return unless compute_phase_angle?
 
@@ -137,6 +138,8 @@ module Astronoby
 
     private
 
+    # By default, Solar System bodies have a phase angle.
+    # Override this method in subclasses when non-applicable.
     def compute_phase_angle?
       true
     end

--- a/lib/astronoby/bodies/solar_system_body.rb
+++ b/lib/astronoby/bodies/solar_system_body.rb
@@ -17,7 +17,7 @@ module Astronoby
     URANUS_BARYCENTER = 7
     NEPTUNE_BARYCENTER = 8
 
-    attr_reader :geometric, :instant
+    attr_reader :geometric, :instant, :phase_angle
 
     def self.geometric(ephem:, instant:)
       compute_geometric(ephem: ephem, instant: instant)
@@ -77,6 +77,7 @@ module Astronoby
           target: @geometric,
           ephem: ephem
         )
+      compute_phase_angle(ephem) if compute_phase_angle?
     end
 
     def astrometric
@@ -127,10 +128,49 @@ module Astronoby
       )
     end
 
+    # @return [Float, nil] Moon's illuminated fraction
+    def illuminated_fraction
+      return unless compute_phase_angle?
+
+      @illuminated_fraction ||= (1 + phase_angle.cos) / 2.0
+    end
+
     private
+
+    def compute_phase_angle?
+      true
+    end
 
     def compute_geometric(ephem)
       self.class.compute_geometric(ephem: ephem, instant: @instant)
+    end
+
+    # Source:
+    #  Title: Astronomical Algorithms
+    #  Author: Jean Meeus
+    #  Edition: 2nd edition
+    #  Chapter: 48 - Illuminated Fraction of the Moon's Disk
+    def compute_phase_angle(ephem)
+      @phase_angle ||= begin
+        sun = Sun.new(instant: @instant, ephem: ephem)
+        geocentric_elongation = Angle.acos(
+          sun.apparent.equatorial.declination.sin *
+          apparent.equatorial.declination.sin +
+          sun.apparent.equatorial.declination.cos *
+          apparent.equatorial.declination.cos *
+          (
+            sun.apparent.equatorial.right_ascension -
+              apparent.equatorial.right_ascension
+          ).cos
+        )
+
+        term1 = sun.astrometric.distance.km * geocentric_elongation.sin
+        term2 = astrometric.distance.km -
+          sun.astrometric.distance.km * geocentric_elongation.cos
+        angle = Angle.atan(term1 / term2)
+        Astronoby::Util::Trigonometry
+          .adjustement_for_arctangent(term1, term2, angle)
+      end
     end
   end
 end

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -37,5 +37,11 @@ module Astronoby
           ).hours * Constants::SECONDS_PER_HOUR
       ).round
     end
+
+    private
+
+    def compute_phase_angle?
+      false
+    end
   end
 end

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -40,6 +40,7 @@ module Astronoby
 
     private
 
+    # Phase angle depends on sunlight, therefore not applicable for the Sun.
     def compute_phase_angle?
       false
     end

--- a/spec/astronoby/bodies/earth_spec.rb
+++ b/spec/astronoby/bodies/earth_spec.rb
@@ -284,4 +284,30 @@ RSpec.describe Astronoby::Earth do
         .to eq([0, 0, 0])
     end
   end
+
+  describe "#phase_angle" do
+    it "returns nil" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      phase_angle = planet.phase_angle
+
+      expect(phase_angle).to be_nil
+    end
+  end
+
+  describe "#illuminated_fraction" do
+    it "returns the illuminated fraction for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      illuminated_fraction = planet.illuminated_fraction
+
+      expect(illuminated_fraction).to be_nil
+    end
+  end
 end

--- a/spec/astronoby/bodies/jupiter_spec.rb
+++ b/spec/astronoby/bodies/jupiter_spec.rb
@@ -404,4 +404,34 @@ RSpec.describe Astronoby::Jupiter do
       end
     end
   end
+
+  describe "#phase_angle" do
+    it "returns the phase angle for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      phase_angle = planet.phase_angle
+
+      expect(phase_angle.str(:dms)).to eq "+2° 45′ 2.241″"
+      # IMCCE:    +2° 44′ 42.7199″
+      # Horizons: +2° 45′ 11.5199″
+      # Skyfield: +2° 45′ 6.0″
+    end
+  end
+
+  describe "#illuminated_fraction" do
+    it "returns the illuminated fraction for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      illuminated_fraction = planet.illuminated_fraction
+
+      expect(illuminated_fraction.round(4)).to eq 0.9994
+      # Skyfield: 0.9994
+    end
+  end
 end

--- a/spec/astronoby/bodies/mars_spec.rb
+++ b/spec/astronoby/bodies/mars_spec.rb
@@ -404,4 +404,34 @@ RSpec.describe Astronoby::Mars do
       end
     end
   end
+
+  describe "#phase_angle" do
+    it "returns the phase angle for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      phase_angle = planet.phase_angle
+
+      expect(phase_angle.str(:dms)).to eq "+30° 8′ 42.3982″"
+      # IMCCE:    +30° 8′ 53.88″
+      # Horizons: +30° 8′ 26.52″
+      # Skyfield: +30° 8′ 41.0″
+    end
+  end
+
+  describe "#illuminated_fraction" do
+    it "returns the illuminated fraction for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      illuminated_fraction = planet.illuminated_fraction
+
+      expect(illuminated_fraction.round(4)).to eq 0.9324
+      # Skyfield: 0.9324
+    end
+  end
 end

--- a/spec/astronoby/bodies/mercury_spec.rb
+++ b/spec/astronoby/bodies/mercury_spec.rb
@@ -404,4 +404,34 @@ RSpec.describe Astronoby::Mercury do
       end
     end
   end
+
+  describe "#phase_angle" do
+    it "returns the phase angle for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      phase_angle = planet.phase_angle
+
+      expect(phase_angle.str(:dms)).to eq "+121° 7′ 10.6495″"
+      # IMCCE:    +121° 7′ 32.16″
+      # Horizons: +121° 6′ 47.16″
+      # Skyfield: +121° 7′ 46.2″
+    end
+  end
+
+  describe "#illuminated_fraction" do
+    it "returns the illuminated fraction for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      illuminated_fraction = planet.illuminated_fraction
+
+      expect(illuminated_fraction.round(4)).to eq 0.2416
+      # Skyfield: 0.2415
+    end
+  end
 end

--- a/spec/astronoby/bodies/moon_spec.rb
+++ b/spec/astronoby/bodies/moon_spec.rb
@@ -457,16 +457,18 @@ RSpec.describe Astronoby::Moon do
   end
 
   describe "#phase_angle" do
-    it "returns the phase angle for 2025-04-12" do
-      time = Time.utc(2025, 4, 12)
+    it "returns the phase angle for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
       instant = Astronoby::Instant.from_time(time)
       ephem = test_ephem_moon
       moon = described_class.new(instant: instant, ephem: ephem)
 
       phase_angle = moon.phase_angle
 
-      expect(phase_angle.degrees.round(4)).to eq 11.0746
-      # Result from IMCCE: 11.0802°
+      expect(phase_angle.str(:dms)).to eq "+38° 15′ 23.6455″"
+      # IMCCE:    +38° 15′ 3.9599″
+      # Horizons: +38° 15′ 8.64″
+      # Skyfield: +38° 15′ 3.7″
     end
   end
 

--- a/spec/astronoby/bodies/neptune_spec.rb
+++ b/spec/astronoby/bodies/neptune_spec.rb
@@ -404,4 +404,34 @@ RSpec.describe Astronoby::Neptune do
       end
     end
   end
+
+  describe "#phase_angle" do
+    it "returns the phase angle for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      phase_angle = planet.phase_angle
+
+      expect(phase_angle.str(:dms)).to eq "+1° 50′ 6.2918″"
+      # IMCCE:    +1° 50′ 12.8399″
+      # Horizons: +1° 50′ 9.6″
+      # Skyfield: +1° 50′ 6.0″
+    end
+  end
+
+  describe "#illuminated_fraction" do
+    it "returns the illuminated fraction for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      illuminated_fraction = planet.illuminated_fraction
+
+      expect(illuminated_fraction.round(4)).to eq 0.9997
+      # Skyfield: 0.9997
+    end
+  end
 end

--- a/spec/astronoby/bodies/saturn_spec.rb
+++ b/spec/astronoby/bodies/saturn_spec.rb
@@ -404,4 +404,34 @@ RSpec.describe Astronoby::Saturn do
       end
     end
   end
+
+  describe "#phase_angle" do
+    it "returns the phase angle for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      phase_angle = planet.phase_angle
+
+      expect(phase_angle.str(:dms)).to eq "+5° 43′ 54.2226″"
+      # IMCCE:    +5° 43′ 59.8799″
+      # Horizons: +5° 43′ 59.52″
+      # Skyfield: +5° 43′ 53.3″
+    end
+  end
+
+  describe "#illuminated_fraction" do
+    it "returns the illuminated fraction for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      illuminated_fraction = planet.illuminated_fraction
+
+      expect(illuminated_fraction.round(4)).to eq 0.9975
+      # Skyfield: 0.9975
+    end
+  end
 end

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -591,4 +591,30 @@ RSpec.describe Astronoby::Sun do
       # Value from Celestial Calculations: 187
     end
   end
+
+  describe "#phase_angle" do
+    it "returns nil" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem_sun
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      phase_angle = planet.phase_angle
+
+      expect(phase_angle).to be_nil
+    end
+  end
+
+  describe "#illuminated_fraction" do
+    it "returns nil" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem_sun
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      illuminated_fraction = planet.illuminated_fraction
+
+      expect(illuminated_fraction).to be_nil
+    end
+  end
 end

--- a/spec/astronoby/bodies/uranus_spec.rb
+++ b/spec/astronoby/bodies/uranus_spec.rb
@@ -404,4 +404,34 @@ RSpec.describe Astronoby::Uranus do
       end
     end
   end
+
+  describe "#phase_angle" do
+    it "returns the phase angle for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      phase_angle = planet.phase_angle
+
+      expect(phase_angle.str(:dms)).to eq "+2° 20′ 13.0065″"
+      # IMCCE:    +2° 20′ 0.5999″
+      # Horizons: +2° 20′ 17.8799″
+      # Skyfield: +2° 20′ 13.6″
+    end
+  end
+
+  describe "#illuminated_fraction" do
+    it "returns the illuminated fraction for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      illuminated_fraction = planet.illuminated_fraction
+
+      expect(illuminated_fraction.round(4)).to eq 0.9996
+      # Skyfield: 0.9996
+    end
+  end
 end

--- a/spec/astronoby/bodies/venus_spec.rb
+++ b/spec/astronoby/bodies/venus_spec.rb
@@ -404,4 +404,34 @@ RSpec.describe Astronoby::Venus do
       end
     end
   end
+
+  describe "#phase_angle" do
+    it "returns the phase angle for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      phase_angle = planet.phase_angle
+
+      expect(phase_angle.str(:dms)).to eq "+67° 54′ 44.5645″"
+      # IMCCE:    +67° 54′ 27.36″
+      # Horizons: +67° 55′ 6.24″
+      # Skyfield: +67° 54′ 35.3″
+    end
+  end
+
+  describe "#illuminated_fraction" do
+    it "returns the illuminated fraction for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      illuminated_fraction = planet.illuminated_fraction
+
+      expect(illuminated_fraction.round(4)).to eq 0.688
+      # Skyfield: 0.688
+    end
+  end
 end


### PR DESCRIPTION
While generally mostly interesting for the Moon, the phase angle and illuminated fraction are two figures that can be useful for anticipating how a planet looks like.

This is particularly the case for Mercury and Venus. As inferior planets (with orbits closer to the Sun than the Earth), they are never observed fully illuminated and always show a phase.

For superior planets, the information is less interesting as we constantly see them almost completely illuminated. But still, the information is there.

Because the phase angle depends on the vector between the sun and the observer, the sun needs to be computed for each planet instance. This isn't great, however the new feature of caching should help.

`#phase_angle` returns an `Astronoby::Angle` object, `#illuminated_fraction` returns a`Float`.

Because the phase angle depends on the Sun, because in Astronoby an apparent position is geocentric, is doesn't make sense for `Astronoby::Sun` and `Astronoby::Earth` to have values for these two methods. Therefore, both classes return `nil` for both methods.

Values have been compared with the IMCCE, JPL Horizons and Skyfield.