### PR TITLE
Apparent magnitude

### DIFF
--- a/lib/astronoby/bodies/earth.rb
+++ b/lib/astronoby/bodies/earth.rb
@@ -15,14 +15,11 @@ module Astronoby
       end
     end
 
-    def phase_angle
-      nil
-    end
-
     private
 
-    # Phase angle is geocentric, therefore non-applicable for Earth.
-    def compute_phase_angle?
+    # Attributes that require Sun data like phase angle or magnitude are not
+    # applicable for Earth.
+    def requires_sun_data?
       false
     end
 

--- a/lib/astronoby/bodies/jupiter.rb
+++ b/lib/astronoby/bodies/jupiter.rb
@@ -3,9 +3,26 @@
 module Astronoby
   class Jupiter < SolarSystemBody
     EQUATORIAL_RADIUS = Distance.from_meters(71_492_000)
+    ABSOLUTE_MAGNITUDE = -9.395
 
     def self.ephemeris_segments(_ephem_source)
       [[SOLAR_SYSTEM_BARYCENTER, JUPITER_BARYCENTER]]
+    end
+
+    def self.absolute_magnitude
+      ABSOLUTE_MAGNITUDE
+    end
+
+    private
+
+    # Source:
+    #  Title: Computing Apparent Planetary Magnitudes for The Astronomical
+    #    Almanac (2018)
+    #  Authors: Anthony Mallama and James L. Hilton
+    def magnitude_correction_term
+      phase_angle_degrees = phase_angle.degrees
+      -3.7 * 10**-4 * phase_angle_degrees +
+        6.16 * 10**-4 * phase_angle_degrees * phase_angle_degrees
     end
   end
 end

--- a/lib/astronoby/bodies/mars.rb
+++ b/lib/astronoby/bodies/mars.rb
@@ -3,9 +3,26 @@
 module Astronoby
   class Mars < SolarSystemBody
     EQUATORIAL_RADIUS = Distance.from_meters(3_396_200)
+    ABSOLUTE_MAGNITUDE = -1.601
 
     def self.ephemeris_segments(_ephem_source)
       [[SOLAR_SYSTEM_BARYCENTER, MARS_BARYCENTER]]
+    end
+
+    def self.absolute_magnitude
+      ABSOLUTE_MAGNITUDE
+    end
+
+    private
+
+    # Source:
+    #  Title: Computing Apparent Planetary Magnitudes for The Astronomical
+    #    Almanac (2018)
+    #  Authors: Anthony Mallama and James L. Hilton
+    def magnitude_correction_term
+      phase_angle_degrees = phase_angle.degrees
+      2.267 * 10**-2 * phase_angle_degrees -
+        1.302 * 10**-4 * phase_angle_degrees * phase_angle_degrees
     end
   end
 end

--- a/lib/astronoby/bodies/mercury.rb
+++ b/lib/astronoby/bodies/mercury.rb
@@ -3,9 +3,30 @@
 module Astronoby
   class Mercury < SolarSystemBody
     EQUATORIAL_RADIUS = Distance.from_meters(2_439_700)
+    ABSOLUTE_MAGNITUDE = -0.613
 
     def self.ephemeris_segments(_ephem_source)
       [[SOLAR_SYSTEM_BARYCENTER, MERCURY_BARYCENTER]]
+    end
+
+    def self.absolute_magnitude
+      ABSOLUTE_MAGNITUDE
+    end
+
+    private
+
+    # Source:
+    #  Title: Computing Apparent Planetary Magnitudes for The Astronomical
+    #    Almanac (2018)
+    #  Authors: Anthony Mallama and James L. Hilton
+    def magnitude_correction_term
+      phase_angle_degrees = phase_angle.degrees
+      6.328 * 10**-2 * phase_angle_degrees -
+        1.6336 * 10**-3 * phase_angle_degrees * phase_angle_degrees +
+        3.3634 * 10**-5 * phase_angle_degrees**3 -
+        3.4265 * 10**-7 * phase_angle_degrees**4 +
+        1.6893 * 10**-9 * phase_angle_degrees**5 -
+        3.0334 * 10**-12 * phase_angle_degrees**6
     end
   end
 end

--- a/lib/astronoby/bodies/moon.rb
+++ b/lib/astronoby/bodies/moon.rb
@@ -4,6 +4,7 @@ module Astronoby
   class Moon < SolarSystemBody
     SEMIDIAMETER_VARIATION = 0.7275
     EQUATORIAL_RADIUS = Distance.from_meters(1_737_400)
+    ABSOLUTE_MAGNITUDE = 0.28
 
     def self.ephemeris_segments(ephem_source)
       if ephem_source == ::Ephem::SPK::JPL_DE
@@ -32,6 +33,10 @@ module Astronoby
       Events::MoonPhases.phases_for(year: year, month: month)
     end
 
+    def self.absolute_magnitude
+      ABSOLUTE_MAGNITUDE
+    end
+
     # @return [Float] Phase fraction, from 0 to 1
     def current_phase_fraction
       mean_elongation.degrees / Constants::DEGREES_PER_CIRCLE
@@ -58,6 +63,31 @@ module Astronoby
 
     def elapsed_centuries
       (@instant.tt - JulianDate::DEFAULT_EPOCH) / Constants::DAYS_PER_JULIAN_CENTURY
+    end
+
+    private
+
+    # Source:
+    #  Title: Computing Apparent Planetary Magnitudes for The Astronomical
+    #    Almanac (2018)
+    #  Authors: Anthony Mallama and James L. Hilton
+    def magnitude_correction_term
+      phase_angle_degrees = phase_angle.degrees
+      if phase_angle_degrees <= 150 && current_phase_fraction <= 0.5
+        2.9994 * 10**-2 * phase_angle_degrees -
+          1.6057 * 10**-4 * phase_angle_degrees**2 +
+          3.1543 * 10**-6 * phase_angle_degrees**3 -
+          2.0667 * 10**-8 * phase_angle_degrees**4 +
+          6.2553 * 10**-11 * phase_angle_degrees**5
+      elsif phase_angle_degrees <= 150 && current_phase_fraction > 0.5
+        3.3234 * 10**-2 * phase_angle_degrees -
+          3.0725 * 10**-4 * phase_angle_degrees**2 +
+          6.1575 * 10**-6 * phase_angle_degrees**3 -
+          4.7723 * 10**-8 * phase_angle_degrees**4 +
+          1.4681 * 10**-10 * phase_angle_degrees**5
+      else
+        super
+      end
     end
   end
 end

--- a/lib/astronoby/bodies/neptune.rb
+++ b/lib/astronoby/bodies/neptune.rb
@@ -3,9 +3,30 @@
 module Astronoby
   class Neptune < SolarSystemBody
     EQUATORIAL_RADIUS = Distance.from_meters(24_764_000)
+    ABSOLUTE_MAGNITUDE = -7.0
 
     def self.ephemeris_segments(_ephem_source)
       [[SOLAR_SYSTEM_BARYCENTER, NEPTUNE_BARYCENTER]]
+    end
+
+    def self.absolute_magnitude
+      ABSOLUTE_MAGNITUDE
+    end
+
+    private
+
+    # Source:
+    #  Title: Computing Apparent Planetary Magnitudes for The Astronomical
+    #    Almanac (2018)
+    #  Authors: Anthony Mallama and James L. Hilton
+    def magnitude_correction_term
+      phase_angle_degrees = phase_angle.degrees
+      if phase_angle_degrees < 133 && @instant.tt > JulianDate::J2000
+        7.944 * 10**-3 * phase_angle_degrees +
+          9.617 * 10**-5 * phase_angle_degrees * phase_angle_degrees
+      else
+        super
+      end
     end
   end
 end

--- a/lib/astronoby/bodies/saturn.rb
+++ b/lib/astronoby/bodies/saturn.rb
@@ -3,9 +3,35 @@
 module Astronoby
   class Saturn < SolarSystemBody
     EQUATORIAL_RADIUS = Distance.from_meters(60_268_000)
+    ABSOLUTE_MAGNITUDE = -8.914
 
     def self.ephemeris_segments(_ephem_source)
       [[SOLAR_SYSTEM_BARYCENTER, SATURN_BARYCENTER]]
+    end
+
+    def self.absolute_magnitude
+      ABSOLUTE_MAGNITUDE
+    end
+
+    private
+
+    # Source:
+    #  Title: Computing Apparent Planetary Magnitudes for The Astronomical
+    #    Almanac (2018)
+    #  Authors: Anthony Mallama and James L. Hilton
+    def magnitude_correction_term
+      phase_angle_degrees = phase_angle.degrees
+      if phase_angle_degrees <= 6
+        -0.036 -
+          3.7 * 10**-4 * phase_angle_degrees +
+          6.16 * 10**-4 * phase_angle_degrees * phase_angle_degrees
+      else
+        0.026 +
+          2.446 * 10**-4 * phase_angle_degrees +
+          2.672 * 10**-4 * phase_angle_degrees * phase_angle_degrees -
+          1.505 * 10**-6 * phase_angle_degrees**3 +
+          4.767 * 10**-9 * phase_angle_degrees**4
+      end
     end
   end
 end

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -3,9 +3,26 @@
 module Astronoby
   class Sun < SolarSystemBody
     EQUATORIAL_RADIUS = Distance.from_meters(695_700_000)
+    ABSOLUTE_MAGNITUDE = -26.74
 
     def self.ephemeris_segments(_ephem_source)
       [[SOLAR_SYSTEM_BARYCENTER, SUN]]
+    end
+
+    def self.absolute_magnitude
+      ABSOLUTE_MAGNITUDE
+    end
+
+    # Source:
+    #  Title: Explanatory Supplement to the Astronomical Almanac
+    #  Authors: Sean E. Urban and P. Kenneth Seidelmann
+    #  Edition: University Science Books
+    #  Chapter: 10.3 - Phases and Magnitudes
+    # Apparent magnitude of the body, as seen from Earth.
+    # @return [Float] Apparent magnitude of the body.
+    def apparent_magnitude
+      @apparent_magnitude ||=
+        self.class.absolute_magnitude + 5 * Math.log10(astrometric.distance.au)
     end
 
     # Source:

--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -40,8 +40,7 @@ module Astronoby
 
     private
 
-    # Phase angle depends on sunlight, therefore not applicable for the Sun.
-    def compute_phase_angle?
+    def requires_sun_data?
       false
     end
   end

--- a/lib/astronoby/bodies/uranus.rb
+++ b/lib/astronoby/bodies/uranus.rb
@@ -3,9 +3,14 @@
 module Astronoby
   class Uranus < SolarSystemBody
     EQUATORIAL_RADIUS = Distance.from_meters(25_559_000)
+    ABSOLUTE_MAGNITUDE = -7.11
 
     def self.ephemeris_segments(_ephem_source)
       [[SOLAR_SYSTEM_BARYCENTER, URANUS_BARYCENTER]]
+    end
+
+    def self.absolute_magnitude
+      ABSOLUTE_MAGNITUDE
     end
   end
 end

--- a/lib/astronoby/bodies/venus.rb
+++ b/lib/astronoby/bodies/venus.rb
@@ -3,9 +3,34 @@
 module Astronoby
   class Venus < SolarSystemBody
     EQUATORIAL_RADIUS = Distance.from_meters(6_051_800)
+    ABSOLUTE_MAGNITUDE = -4.384
 
     def self.ephemeris_segments(_ephem_source)
       [[SOLAR_SYSTEM_BARYCENTER, VENUS_BARYCENTER]]
+    end
+
+    def self.absolute_magnitude
+      ABSOLUTE_MAGNITUDE
+    end
+
+    private
+
+    # Source:
+    #  Title: Computing Apparent Planetary Magnitudes for The Astronomical
+    #    Almanac (2018)
+    #  Authors: Anthony Mallama and James L. Hilton
+    def magnitude_correction_term
+      phase_angle_degrees = phase_angle.degrees
+      if phase_angle_degrees < 163.7
+        -1.044 * 10**-3 * phase_angle_degrees +
+          3.687 * 10**-4 * phase_angle_degrees * phase_angle_degrees -
+          2.814 * 10**-6 * phase_angle_degrees**3 +
+          8.938 * 10**-9 * phase_angle_degrees**4
+
+      else
+        240.44228 - 2.81914 * phase_angle_degrees +
+          8.39034 * 10**-3 * phase_angle_degrees * phase_angle_degrees
+      end
     end
   end
 end

--- a/spec/astronoby/bodies/earth_spec.rb
+++ b/spec/astronoby/bodies/earth_spec.rb
@@ -310,4 +310,17 @@ RSpec.describe Astronoby::Earth do
       expect(illuminated_fraction).to be_nil
     end
   end
+
+  describe "#apparent_magnitude" do
+    it "returns nil" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem_sun
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude).to be_nil
+    end
+  end
 end

--- a/spec/astronoby/bodies/jupiter_spec.rb
+++ b/spec/astronoby/bodies/jupiter_spec.rb
@@ -434,4 +434,21 @@ RSpec.describe Astronoby::Jupiter do
       # Skyfield: 0.9994
     end
   end
+
+  describe "#apparent_magnitude" do
+    it "returns the apparent magnitude for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude.round(2)).to eq(-1.9)
+      # IMCCE:      -1.9
+      # Horizons:   -1.895
+      # Stellarium: -1.90
+      # Skyfield:   -1.90
+    end
+  end
 end

--- a/spec/astronoby/bodies/mars_spec.rb
+++ b/spec/astronoby/bodies/mars_spec.rb
@@ -434,4 +434,21 @@ RSpec.describe Astronoby::Mars do
       # Skyfield: 0.9324
     end
   end
+
+  describe "#apparent_magnitude" do
+    it "returns the apparent magnitude for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude.round(2)).to eq(1.54)
+      # IMCCE:      1.54
+      # Horizons:   1.507
+      # Stellarium: 1.51
+      # Skyfield:   1.55
+    end
+  end
 end

--- a/spec/astronoby/bodies/mercury_spec.rb
+++ b/spec/astronoby/bodies/mercury_spec.rb
@@ -434,4 +434,21 @@ RSpec.describe Astronoby::Mercury do
       # Skyfield: 0.2415
     end
   end
+
+  describe "#apparent_magnitude" do
+    it "returns the apparent magnitude for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude.round(2)).to eq(1.11)
+      # IMCCE:      1.13
+      # Horizons:   1.131
+      # Stellarium: 1.13
+      # Skyfield:   1.14
+    end
+  end
 end

--- a/spec/astronoby/bodies/moon_spec.rb
+++ b/spec/astronoby/bodies/moon_spec.rb
@@ -560,4 +560,48 @@ RSpec.describe Astronoby::Moon do
       expect(phase_fraction.round(2)).to eq 0.66
     end
   end
+
+  describe "#apparent_magnitude" do
+    it "returns the apparent magnitude for 2025-07-01" do
+      time = Time.utc(2025, 7, 1)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude.round(2)).to eq(-9.04)
+      # IMCCE:      -8.87
+      # Horizons:   -9.177
+      # Stellarium: -9.41
+    end
+
+    it "returns the apparent magnitude for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude.round(2)).to eq(-11.58)
+      # IMCCE:      -11.38
+      # Horizons:   -11.703
+      # Stellarium: -11.78
+    end
+
+    it "returns the apparent magnitude for 2025-07-26" do
+      time = Time.utc(2025, 7, 26)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude.round(2)).to eq(-8.3)
+      # IMCCE:      -3.56
+      # Horizons:   -5.497
+      # Stellarium: -4.57
+    end
+  end
 end

--- a/spec/astronoby/bodies/neptune_spec.rb
+++ b/spec/astronoby/bodies/neptune_spec.rb
@@ -434,4 +434,21 @@ RSpec.describe Astronoby::Neptune do
       # Skyfield: 0.9997
     end
   end
+
+  describe "#apparent_magnitude" do
+    it "returns the apparent magnitude for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude.round(2)).to eq(7.74)
+      # IMCCE:      7.74
+      # Horizons:   7.729
+      # Stellarium: 7.74
+      # Skyfield:   7.73
+    end
+  end
 end

--- a/spec/astronoby/bodies/saturn_spec.rb
+++ b/spec/astronoby/bodies/saturn_spec.rb
@@ -434,4 +434,36 @@ RSpec.describe Astronoby::Saturn do
       # Skyfield: 0.9975
     end
   end
+
+  describe "#apparent_magnitude" do
+    it "returns the apparent magnitude for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude.round(2)).to eq(0.79)
+      # IMCCE:      0.79
+      # Horizons:   0.893
+      # Stellarium: 0.89
+      # Skyfield:   0.89
+    end
+
+    it "returns the apparent magnitude for 2025-06-19" do
+      time = Time.utc(2025, 6, 19)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude.round(2)).to eq(0.94)
+      # IMCCE:      0.89
+      # Horizons:   1.011
+      # Stellarium: 1.01
+      # Skyfield:   1.01
+    end
+  end
 end

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -617,4 +617,17 @@ RSpec.describe Astronoby::Sun do
       expect(illuminated_fraction).to be_nil
     end
   end
+
+  describe "#apparent_magnitude" do
+    it "returns nil" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem_sun
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude).to be_nil
+    end
+  end
 end

--- a/spec/astronoby/bodies/sun_spec.rb
+++ b/spec/astronoby/bodies/sun_spec.rb
@@ -619,7 +619,7 @@ RSpec.describe Astronoby::Sun do
   end
 
   describe "#apparent_magnitude" do
-    it "returns nil" do
+    it "returns the apparent magnitude for 2025-07-14" do
       time = Time.utc(2025, 7, 14)
       instant = Astronoby::Instant.from_time(time)
       ephem = test_ephem_sun
@@ -627,7 +627,10 @@ RSpec.describe Astronoby::Sun do
 
       apparent_magnitude = planet.apparent_magnitude
 
-      expect(apparent_magnitude).to be_nil
+      expect(apparent_magnitude.round(2)).to eq(-26.7)
+      # IMCCE:      -26.7
+      # Horizons:   -26.707
+      # Stellarium: -26.71
     end
   end
 end

--- a/spec/astronoby/bodies/uranus_spec.rb
+++ b/spec/astronoby/bodies/uranus_spec.rb
@@ -434,4 +434,21 @@ RSpec.describe Astronoby::Uranus do
       # Skyfield: 0.9996
     end
   end
+
+  describe "#apparent_magnitude" do
+    it "returns the apparent magnitude for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude.round(2)).to eq(5.86)
+      # IMCCE:      5.88
+      # Horizons:   5.803
+      # Stellarium: 5.82
+      # Skyfield:   5.80
+    end
+  end
 end

--- a/spec/astronoby/bodies/venus_spec.rb
+++ b/spec/astronoby/bodies/venus_spec.rb
@@ -434,4 +434,36 @@ RSpec.describe Astronoby::Venus do
       # Skyfield: 0.688
     end
   end
+
+  describe "#apparent_magnitude" do
+    it "returns the apparent magnitude for 2025-07-14" do
+      time = Time.utc(2025, 7, 14)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude.round(2)).to eq(-4.07)
+      # IMCCE:      -4.07
+      # Horizons:   -4.065
+      # Stellarium: -4.07
+      # Skyfield:   -4.07
+    end
+
+    it "returns the apparent magnitude for 2025-03-22" do
+      time = Time.utc(2025, 3, 22)
+      instant = Astronoby::Instant.from_time(time)
+      ephem = test_ephem
+      planet = described_class.new(instant: instant, ephem: ephem)
+
+      apparent_magnitude = planet.apparent_magnitude
+
+      expect(apparent_magnitude.round(2)).to eq(-4.22)
+      # IMCCE:      -4.22
+      # Horizons:   -4.220
+      # Stellarium: -4.22
+      # Skyfield:   -4.20
+    end
+  end
 end


### PR DESCRIPTION
Magnitude is a measure of the luminosity. The more luminous an object, the lower its magnitude number.

The apparent magnitude represents the brightness of the object seen from Earth. Note that is doesn't account the atmospheric effect.

Most planets have many different coefficients. It is because there is no single formula for describing the brightness of all the variety of the planets.
Note that some cases are ignored and fall back to a default (less accurate) formula:
- Saturn's rings add significant brightness but taking them into account means calculating their inclination, which is a complex one I don't want to deal with right now
- Uranus uses the default formula as the accurate one depends on a complex correction term called "Uranus' sub-Earth and sub-solar latitudes", which again is just too much burden for now

Values have been tested against the IMCCE, JPL Horizons, Stellarium and Skyfield library. They match these sources most of the time, otherwise the difference is too small to be noticed in any amateur purpose.

Since `phase_angle` has been added to planets, the position of the Sun in different reference frames is necessary for multiple planetary calculations. Therefore, the whole sun object is now saved on the planet for computing different data.
