### PR TITLE
Rename "epoch"

### DIFF
--- a/lib/astronoby/bodies/sun.rb
+++ b/lib/astronoby/bodies/sun.rb
@@ -42,7 +42,7 @@ module Astronoby
         t**4 / 15_300 -
         t**5 / 2_000_000) % Constants::DEGREES_PER_CIRCLE
       nutation = Nutation.new(instant: instant).nutation_in_longitude
-      obliquity = TrueObliquity.for_epoch(@instant.julian_date)
+      obliquity = TrueObliquity.at(@instant)
 
       (
         Angle

--- a/lib/astronoby/coordinates/equatorial.rb
+++ b/lib/astronoby/coordinates/equatorial.rb
@@ -82,8 +82,8 @@ module Astronoby
       #  Author: J. L. Lawrence
       #  Edition: MIT Press
       #  Chapter: 4 - Orbits and Coordinate Systems
-      def to_ecliptic(epoch:)
-        mean_obliquity = MeanObliquity.for_epoch(epoch)
+      def to_ecliptic(instant:)
+        mean_obliquity = MeanObliquity.at(instant)
 
         y = Angle.from_radians(
           @right_ascension.sin * mean_obliquity.cos +

--- a/lib/astronoby/mean_obliquity.rb
+++ b/lib/astronoby/mean_obliquity.rb
@@ -12,11 +12,11 @@ module Astronoby
     EPOCH_OF_REFERENCE = JulianDate::DEFAULT_EPOCH
     OBLIQUITY_OF_REFERENCE = 23.4392794
 
-    def self.for_epoch(epoch)
-      return obliquity_of_reference if epoch == EPOCH_OF_REFERENCE
+    def self.at(instant)
+      return obliquity_of_reference if instant.julian_date == EPOCH_OF_REFERENCE
 
       t = Rational(
-        epoch - EPOCH_OF_REFERENCE,
+        instant.julian_date - EPOCH_OF_REFERENCE,
         Constants::DAYS_PER_JULIAN_CENTURY
       )
 

--- a/lib/astronoby/mean_obliquity.rb
+++ b/lib/astronoby/mean_obliquity.rb
@@ -20,25 +20,23 @@ module Astronoby
         Constants::DAYS_PER_JULIAN_CENTURY
       )
 
-      epsilon0 = obliquity_of_reference_in_milliarcseconds
+      epsilon0 = obliquity_of_reference_in_arcseconds
       c1 = -46.836769
       c2 = -0.0001831
       c3 = 0.00200340
       c4 = -0.000000576
       c5 = -0.0000000434
 
-      Angle.from_dms(
-        0,
-        0,
+      Angle.from_degree_arcseconds(
         epsilon0 + t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5))))
       )
     end
 
     def self.obliquity_of_reference
-      Angle.from_dms(0, 0, obliquity_of_reference_in_milliarcseconds)
+      Angle.from_degree_arcseconds(obliquity_of_reference_in_arcseconds)
     end
 
-    def self.obliquity_of_reference_in_milliarcseconds
+    def self.obliquity_of_reference_in_arcseconds
       84381.406
     end
   end

--- a/lib/astronoby/nutation.rb
+++ b/lib/astronoby/nutation.rb
@@ -104,7 +104,7 @@ module Astronoby
 
     # @return [Matrix] The nutation matrix
     def matrix
-      mean_obliquity = MeanObliquity.for_epoch(@instant.tt)
+      mean_obliquity = MeanObliquity.at(@instant)
       true_obliquity = mean_obliquity + nutation_in_obliquity
       build_nutation_matrix(
         mean_obliquity: mean_obliquity,

--- a/lib/astronoby/observer.rb
+++ b/lib/astronoby/observer.rb
@@ -62,7 +62,7 @@ module Astronoby
     def earth_fixed_rotation_matrix_for(instant)
       dpsi = Nutation.new(instant: instant).nutation_in_longitude
 
-      mean_obliquity = MeanObliquity.for_epoch(instant.tt)
+      mean_obliquity = MeanObliquity.at(instant)
 
       gast = Angle.from_radians(
         Angle.from_hours(instant.gmst).radians +

--- a/lib/astronoby/precession.rb
+++ b/lib/astronoby/precession.rb
@@ -164,7 +164,7 @@ module Astronoby
     end
 
     def eps0
-      @eps0 ||= MeanObliquity.obliquity_of_reference_in_milliarcseconds
+      @eps0 ||= MeanObliquity.obliquity_of_reference_in_arcseconds
     end
   end
 end

--- a/lib/astronoby/reference_frame.rb
+++ b/lib/astronoby/reference_frame.rb
@@ -34,7 +34,8 @@ module Astronoby
       @ecliptic ||= begin
         return Coordinates::Ecliptic.zero if distance.zero?
 
-        equatorial.to_ecliptic(epoch: JulianDate::J2000)
+        j2000 = Instant.from_terrestrial_time(JulianDate::J2000)
+        equatorial.to_ecliptic(instant: j2000)
       end
     end
 

--- a/lib/astronoby/reference_frames/apparent.rb
+++ b/lib/astronoby/reference_frames/apparent.rb
@@ -43,7 +43,7 @@ module Astronoby
       @ecliptic ||= begin
         return Coordinates::Ecliptic.zero if distance.zero?
 
-        equatorial.to_ecliptic(epoch: @instant.tdb)
+        equatorial.to_ecliptic(instant: @instant)
       end
     end
 

--- a/lib/astronoby/reference_frames/mean_of_date.rb
+++ b/lib/astronoby/reference_frames/mean_of_date.rb
@@ -31,7 +31,7 @@ module Astronoby
       @ecliptic ||= begin
         return Coordinates::Ecliptic.zero if distance.zero?
 
-        equatorial.to_ecliptic(epoch: @instant.tdb)
+        equatorial.to_ecliptic(instant: @instant)
       end
     end
   end

--- a/lib/astronoby/reference_frames/topocentric.rb
+++ b/lib/astronoby/reference_frames/topocentric.rb
@@ -52,7 +52,7 @@ module Astronoby
       @ecliptic ||= begin
         return Coordinates::Ecliptic.zero if distance.zero?
 
-        equatorial.to_ecliptic(epoch: @instant.tdb)
+        equatorial.to_ecliptic(instant: @instant)
       end
     end
 

--- a/lib/astronoby/true_obliquity.rb
+++ b/lib/astronoby/true_obliquity.rb
@@ -2,9 +2,8 @@
 
 module Astronoby
   class TrueObliquity
-    def self.for_epoch(epoch)
-      instant = Instant.from_utc_julian_date(epoch)
-      mean_obliquity = MeanObliquity.for_epoch(epoch)
+    def self.at(instant)
+      mean_obliquity = MeanObliquity.at(instant)
       nutation = Nutation.new(instant: instant).nutation_in_obliquity
 
       mean_obliquity + nutation

--- a/spec/astronoby/coordinates/equatorial_spec.rb
+++ b/spec/astronoby/coordinates/equatorial_spec.rb
@@ -202,12 +202,13 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
       it "computes properly" do
         right_ascension = Astronoby::Angle.from_hms(11, 10, 13)
         declination = Astronoby::Angle.from_dms(30, 5, 40)
-        epoch = Astronoby::JulianDate::J2000
+        instant = Astronoby::Instant
+          .from_terrestrial_time(Astronoby::JulianDate::J2000)
 
         ecliptic_coordinates = described_class.new(
           right_ascension: right_ascension,
           declination: declination
-        ).to_ecliptic(epoch: epoch)
+        ).to_ecliptic(instant: instant)
 
         expect(ecliptic_coordinates.latitude.str(:dms)).to(
           eq("+22° 41′ 53.8929″")
@@ -227,12 +228,13 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
       it "computes properly" do
         right_ascension = Astronoby::Angle.from_hms(7, 45, 18.946)
         declination = Astronoby::Angle.from_dms(28, 1, 34.26)
-        epoch = Astronoby::JulianDate::J2000
+        instant = Astronoby::Instant
+          .from_terrestrial_time(Astronoby::JulianDate::J2000)
 
         ecliptic_coordinates = described_class.new(
           right_ascension: right_ascension,
           declination: declination
-        ).to_ecliptic(epoch: epoch)
+        ).to_ecliptic(instant: instant)
 
         expect(ecliptic_coordinates.latitude.str(:dms)).to(
           eq("+6° 41′ 3.0508″")
@@ -252,12 +254,12 @@ RSpec.describe Astronoby::Coordinates::Equatorial do
       it "computes properly" do
         right_ascension = Astronoby::Angle.from_hms(9, 34, 53.32)
         declination = Astronoby::Angle.from_dms(19, 32, 6.01)
-        epoch = Astronoby::JulianDate.from_time(Time.utc(2009, 7, 6, 0, 0, 0))
+        instant = Astronoby::Instant.from_time(Time.utc(2009, 7, 6, 0, 0, 0))
 
         ecliptic_coordinates = described_class.new(
           right_ascension: right_ascension,
           declination: declination
-        ).to_ecliptic(epoch: epoch)
+        ).to_ecliptic(instant: instant)
 
         expect(ecliptic_coordinates.latitude.str(:dms)).to(
           eq("+4° 52′ 31.0228″")

--- a/spec/astronoby/mean_obliquity_spec.rb
+++ b/spec/astronoby/mean_obliquity_spec.rb
@@ -1,21 +1,27 @@
 # frozen_string_literal: true
 
 RSpec.describe Astronoby::MeanObliquity do
-  describe "::for_epoch" do
+  describe "::at" do
     it "returns an angle" do
-      obliquity = described_class.for_epoch(Astronoby::JulianDate::J2000)
+      instant = Astronoby::Instant
+        .from_terrestrial_time(Astronoby::JulianDate::J2000)
+      obliquity = described_class.at(instant)
 
       expect(obliquity).to be_kind_of(Astronoby::Angle)
     end
 
     it "returns the obliquity angle for standard epoch" do
-      obliquity = described_class.for_epoch(Astronoby::JulianDate::J2000)
+      instant = Astronoby::Instant
+        .from_terrestrial_time(Astronoby::JulianDate::J2000)
+      obliquity = described_class.at(instant)
 
       expect(obliquity.degrees).to eq(23.439279444444445)
     end
 
     it "returns the obliquity angle for epoch 1950" do
-      obliquity = described_class.for_epoch(Astronoby::JulianDate::J1950)
+      instant = Astronoby::Instant
+        .from_terrestrial_time(Astronoby::JulianDate::J1950)
+      obliquity = described_class.at(instant)
 
       expect(obliquity.degrees).to eq 23.445784468962604
     end
@@ -27,8 +33,8 @@ RSpec.describe Astronoby::MeanObliquity do
     #  Chapter: 27 - Ecliptic to equatorial coordinate conversion
     context "with real life arguments (book example)" do
       it "computes properly" do
-        epoch = Astronoby::JulianDate.from_time(Time.utc(2009, 7, 6, 0, 0, 0))
-        obliquity = described_class.for_epoch(epoch)
+        instant = Astronoby::Instant.from_time(Time.utc(2009, 7, 6, 0, 0, 0))
+        obliquity = described_class.at(instant)
 
         expect(obliquity.str(:dms)).to eq "+23° 26′ 16.9518″"
       end
@@ -41,8 +47,8 @@ RSpec.describe Astronoby::MeanObliquity do
     #  Chapter: 22 - Nutation and the Obliquity of the Ecliptic
     context "with real life arguments (book example)" do
       it "computes properly" do
-        epoch = Astronoby::JulianDate.from_time(Time.utc(1987, 4, 10, 0, 0, 0))
-        obliquity = described_class.for_epoch(epoch)
+        instant = Astronoby::Instant.from_time(Time.utc(1987, 4, 10, 0, 0, 0))
+        obliquity = described_class.at(instant)
 
         expect(obliquity.str(:dms)).to eq "+23° 26′ 27.3681″"
       end

--- a/spec/astronoby/true_obliquity_spec.rb
+++ b/spec/astronoby/true_obliquity_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Astronoby::TrueObliquity do
-  describe "::for_epoch" do
+  describe "::at" do
     it "returns an angle" do
-      obliquity = described_class.for_epoch(Astronoby::JulianDate::J2000)
+      instant = Astronoby::Instant
+        .from_terrestrial_time(Astronoby::JulianDate::J2000)
+      obliquity = described_class.at(instant)
 
       expect(obliquity).to be_kind_of(Astronoby::Angle)
     end
@@ -15,8 +17,8 @@ RSpec.describe Astronoby::TrueObliquity do
     #  Chapter: 22 - Nutation and the Obliquity of the Ecliptic
     context "with real life arguments (book example)" do
       it "computes properly" do
-        epoch = Astronoby::JulianDate.from_time(Time.utc(1987, 4, 10, 0, 0, 0))
-        obliquity = described_class.for_epoch(epoch)
+        instant = Astronoby::Instant.from_time(Time.utc(1987, 4, 10, 0, 0, 0))
+        obliquity = described_class.at(instant)
 
         expect(obliquity.str(:dms)).to eq "+23° 26′ 36.8137″"
       end


### PR DESCRIPTION
The ambiguous "epoch" term has been partially removed in ab37cdde1209621f010b4b755fd91cf24e11edd5 in favour of "Julian Date".

Multiple methods have been changed:

* `MeanObliquity`: `::for_epoch` to `::at` and now takes an `instant` as parameter
* `MeanObliquity.obliquity_of_reference_in_milliarcseconds` renamed into `obliquity_of_reference_in_arcseconds`
* `TrueObliquity`: `::for_epoch` to `::at` and now takes an `instant` as parameter
* `Coordinates::Equatorial`: `#to_ecliptic` method now takes an `instant` as parameter

This intends to finish this work. The term "epoch" remains in the codebase for equatorial coordinates because it seems it makes more sense in the literature than "instant" or "time", equatorial coordinates are always defined for an epoch.