### PR TITLE
Add `ReferenceFrame#separation_from` for angular separation

### DIFF
--- a/docs/reference_frames.md
+++ b/docs/reference_frames.md
@@ -29,6 +29,8 @@ All reference frames provide this common interface:
 - `#distance`: Distance from the centre (`Astronoby::Distance`)
 - `#equatorial`: Equatorial coordinates (`Astronoby::Coordinates::Equatorial`)
 - `#ecliptic`: Ecliptic coordinates (`Astronoby::Coordinates::Ecliptic`)
+- `#separation_from(other)`: Angular separation to another frame
+  (`Astronoby::Angle`)
 
 ## Geometric
 
@@ -154,6 +156,31 @@ topocentric.horizontal.azimuth.str(:dms, precision: 0)
 ```
 
 You can learn more about observers on the [Observer page].
+
+## Angular separation
+
+Any two frames can be compared with `#separation_from`, which returns the
+angular separation (an `Astronoby::Angle`, between 0° and 180°) between the two
+targets' directions as seen from their shared centre.
+
+The two frames may belong to different kinds of objects (a Solar System body
+and a deep-sky object, for example) as long as they are in the same reference
+frame and at the same instant. Otherwise the separation is not physically
+meaningful and an `Astronoby::IncompatibleArgumentsError` is raised.
+
+```rb
+ephem = Astronoby::Ephem.load("inpop19a.bsp")
+instant = Astronoby::Instant.from_time(Time.utc(2020, 12, 21, 18))
+
+jupiter = Astronoby::Jupiter.new(ephem: ephem, instant: instant)
+saturn = Astronoby::Saturn.new(ephem: ephem, instant: instant)
+
+# The 2020 "Great Conjunction", the closest since 1623
+separation = jupiter.apparent.separation_from(saturn.apparent)
+
+separation.str(:dms, precision: 0)
+# => "+0° 6′ 6″"
+```
 
 ## TEME
 

--- a/lib/astronoby/bodies/solar_system_body.rb
+++ b/lib/astronoby/bodies/solar_system_body.rb
@@ -217,16 +217,7 @@ module Astronoby
       return unless sun
 
       @phase_angle ||= begin
-        geocentric_elongation = Angle.acos(
-          sun.apparent.equatorial.declination.sin *
-          apparent.equatorial.declination.sin +
-          sun.apparent.equatorial.declination.cos *
-          apparent.equatorial.declination.cos *
-          (
-            sun.apparent.equatorial.right_ascension -
-              apparent.equatorial.right_ascension
-          ).cos
-        )
+        geocentric_elongation = sun.apparent.separation_from(apparent)
 
         term1 = sun.astrometric.distance.km * geocentric_elongation.sin
         term2 = astrometric.distance.km -

--- a/lib/astronoby/reference_frame.rb
+++ b/lib/astronoby/reference_frame.rb
@@ -68,5 +68,49 @@ module Astronoby
         @position.magnitude
       end
     end
+
+    # @param other [Astronoby::ReferenceFrame] another frame at the same stage
+    #   and instant
+    # @return [Astronoby::Angle] the angular separation, between 0° and 180°
+    # @raise [Astronoby::IncompatibleArgumentsError] if the frames cannot be
+    #   meaningfully compared
+    def separation_from(other)
+      ensure_comparable!(other)
+      return Angle.zero if @position.zero? || other.position.zero?
+
+      position_vector = @position.map(&:m)
+      other_position_vector = other.position.map(&:m)
+      cross = Util::Maths.cross_product(position_vector, other_position_vector)
+      cross_magnitude = Math.sqrt(Util::Maths.dot_product(cross, cross))
+      dot = Util::Maths.dot_product(position_vector, other_position_vector)
+
+      Angle.from_radians(Math.atan2(cross_magnitude, dot))
+    end
+
+    private
+
+    def ensure_comparable!(other)
+      unless other.is_a?(ReferenceFrame)
+        raise IncompatibleArgumentsError,
+          "Expected an Astronoby::ReferenceFrame, got #{other.class}"
+      end
+
+      unless instance_of?(other.class)
+        raise IncompatibleArgumentsError,
+          "Cannot compute the separation between different reference frames " \
+          "(#{self.class} and #{other.class}); both frames must be at the " \
+          "same stage of the reference frame chain"
+      end
+
+      unless instant == other.instant
+        raise IncompatibleArgumentsError,
+          "Cannot compute the separation between frames at different instants"
+      end
+
+      unless center_identifier == other.center_identifier
+        raise IncompatibleArgumentsError,
+          "Cannot compute the separation between frames with different centers"
+      end
+    end
   end
 end

--- a/lib/astronoby/util/maths.rb
+++ b/lib/astronoby/util/maths.rb
@@ -9,6 +9,14 @@ module Astronoby
         a.zip(b).sum { |x, y| x * y }
       end
 
+      def cross_product(a, b)
+        [
+          a[1] * b[2] - a[2] * b[1],
+          a[2] * b[0] - a[0] * b[2],
+          a[0] * b[1] - a[1] * b[0]
+        ]
+      end
+
       # Find maximum altitude using quadratic interpolation
       # @param t1, t2, t3 [Time] Three consecutive times
       # @param alt1, alt2, alt3 [Float] Corresponding altitudes

--- a/spec/astronoby/reference_frame_spec.rb
+++ b/spec/astronoby/reference_frame_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+RSpec.describe Astronoby::ReferenceFrame do
+  include TestEphemHelper
+
+  describe "#separation_from" do
+    context "during the 2020 Great Conjunction of Jupiter and Saturn" do
+      it "returns the apparent separation" do
+        instant = Astronoby::Instant.from_time(Time.utc(2020, 12, 21, 18))
+        ephem = test_ephem_inpop_2000_2050
+        jupiter = Astronoby::Jupiter.new(instant: instant, ephem: ephem)
+        saturn = Astronoby::Saturn.new(instant: instant, ephem: ephem)
+
+        separation = jupiter.apparent.separation_from(saturn.apparent)
+
+        expect(separation.str(:dms)).to eq "+0° 6′ 6.4252″"
+        # Skyfield: +0° 6′ 6.4257″
+      end
+
+      it "returns the astrometric separation" do
+        instant = Astronoby::Instant.from_time(Time.utc(2020, 12, 21, 18))
+        ephem = test_ephem_inpop_2000_2050
+        jupiter = Astronoby::Jupiter.new(instant: instant, ephem: ephem)
+        saturn = Astronoby::Saturn.new(instant: instant, ephem: ephem)
+
+        separation = jupiter.astrometric.separation_from(saturn.astrometric)
+
+        expect(separation.str(:dms)).to eq "+0° 6′ 6.4068″"
+        # Skyfield: +0° 6′ 6.4068″
+      end
+    end
+
+    context "between Mars and Antares" do
+      it "returns the astrometric separation across body types" do
+        instant = Astronoby::Instant.from_time(Time.utc(2016, 8, 24, 12))
+        ephem = test_ephem_inpop_2000_2050
+        mars = Astronoby::Mars.new(instant: instant, ephem: ephem)
+        antares = Astronoby::DeepSkyObject.new(
+          equatorial_coordinates: Astronoby::Coordinates::Equatorial.new(
+            right_ascension: Astronoby::Angle.from_hms(16, 29, 24.46),
+            declination: Astronoby::Angle.from_dms(-26, 25, 55.2)
+          )
+        ).at(instant, ephem: ephem)
+
+        separation = mars.astrometric.separation_from(antares.astrometric)
+
+        expect(separation.str(:dms)).to eq "+1° 47′ 20.8463″"
+        # Skyfield: +1° 47′ 20.8″
+      end
+    end
+
+    it "is symmetric" do
+      instant = Astronoby::Instant.from_time(Time.utc(2020, 12, 21, 18))
+      ephem = test_ephem_inpop_2000_2050
+      jupiter = Astronoby::Jupiter.new(instant: instant, ephem: ephem)
+      saturn = Astronoby::Saturn.new(instant: instant, ephem: ephem)
+
+      forward = jupiter.apparent.separation_from(saturn.apparent)
+      backward = saturn.apparent.separation_from(jupiter.apparent)
+
+      expect(forward).to eq(backward)
+    end
+
+    context "when the frames are at different stages of the chain" do
+      it "raises an error" do
+        instant = Astronoby::Instant.from_time(Time.utc(2020, 12, 21, 18))
+        ephem = test_ephem_inpop_2000_2050
+        jupiter = Astronoby::Jupiter.new(instant: instant, ephem: ephem)
+        saturn = Astronoby::Saturn.new(instant: instant, ephem: ephem)
+
+        expect { jupiter.astrometric.separation_from(saturn.apparent) }
+          .to raise_error(
+            Astronoby::IncompatibleArgumentsError,
+            /same stage/
+          )
+      end
+    end
+
+    context "when the frames are at different instants" do
+      it "raises an error" do
+        ephem = test_ephem_inpop_2000_2050
+        jupiter = Astronoby::Jupiter.new(
+          instant: Astronoby::Instant.from_time(Time.utc(2020, 12, 21, 18)),
+          ephem: ephem
+        )
+        saturn = Astronoby::Saturn.new(
+          instant: Astronoby::Instant.from_time(Time.utc(2020, 12, 22, 18)),
+          ephem: ephem
+        )
+
+        expect { jupiter.apparent.separation_from(saturn.apparent) }
+          .to raise_error(
+            Astronoby::IncompatibleArgumentsError,
+            /different instants/
+          )
+      end
+    end
+
+    context "when the frames have different centers" do
+      it "raises an error" do
+        instant = Astronoby::Instant.from_time(Time.utc(2020, 12, 21, 18))
+        ephem = test_ephem_inpop_2000_2050
+        jupiter = Astronoby::Jupiter.new(instant: instant, ephem: ephem)
+        paris = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(48.8566),
+          longitude: Astronoby::Angle.from_degrees(2.3522)
+        )
+        sydney = Astronoby::Observer.new(
+          latitude: Astronoby::Angle.from_degrees(-33.8688),
+          longitude: Astronoby::Angle.from_degrees(151.2093)
+        )
+
+        expect {
+          jupiter.observed_by(paris)
+            .separation_from(jupiter.observed_by(sydney))
+        }.to raise_error(
+          Astronoby::IncompatibleArgumentsError,
+          /different centers/
+        )
+      end
+    end
+
+    context "when the other object is not a reference frame" do
+      it "raises an error" do
+        instant = Astronoby::Instant.from_time(Time.utc(2020, 12, 21, 18))
+        ephem = test_ephem_inpop_2000_2050
+        jupiter = Astronoby::Jupiter.new(instant: instant, ephem: ephem)
+
+        expect { jupiter.apparent.separation_from(Object.new) }
+          .to raise_error(Astronoby::IncompatibleArgumentsError)
+      end
+    end
+  end
+end

--- a/spec/astronoby/util/maths_spec.rb
+++ b/spec/astronoby/util/maths_spec.rb
@@ -10,6 +10,26 @@ RSpec.describe Astronoby::Util::Maths do
     end
   end
 
+  describe ".cross_product" do
+    it "returns the cross product of two vectors" do
+      expect(described_class.cross_product([1, 0, 0], [0, 1, 0]))
+        .to eq([0, 0, 1])
+    end
+
+    it "computes the cross product component-wise" do
+      expect(described_class.cross_product([1, 2, 3], [4, 5, 6]))
+        .to eq([-3, 6, -3])
+    end
+
+    it "is anti-commutative" do
+      a = [1, 2, 3]
+      b = [4, 5, 6]
+
+      expect(described_class.cross_product(a, b))
+        .to eq(described_class.cross_product(b, a).map(&:-@))
+    end
+  end
+
   describe ".quadratic_maximum" do
     it "finds the maximum of a simple parabola" do
       # Parabola: y = -x² + 10x - 20 (maximum at x=5, y=5)

--- a/spec/support/test_ephem_helper.rb
+++ b/spec/support/test_ephem_helper.rb
@@ -21,6 +21,11 @@ module TestEphemHelper
     Astronoby::Ephem.load(path)
   end
 
+  def test_ephem_inpop_2000_2050
+    path = File.path("#{__dir__}/data/inpop19a_2000_2050_excerpt.bsp")
+    Astronoby::Ephem.load(path)
+  end
+
   def test_ephem_inpop_full
     path = File.path("#{__dir__}/data/inpop19a.bsp")
     Astronoby::Ephem.load(path)


### PR DESCRIPTION
This adds an angular separation method on `ReferenceFrame` class, so it works uniformly across all frame and body types (planets, `Moon`, `Sun`, deep-sky objects, `TEME`).