### PR TITLE
Fix astrometric position for DSO

### DIFF
--- a/lib/astronoby/bodies/deep_sky_object_position.rb
+++ b/lib/astronoby/bodies/deep_sky_object_position.rb
@@ -65,7 +65,16 @@ module Astronoby
     private
 
     def astrometric_position
-      @astrometric_position ||= if use_stellar_propagation?
+      @astrometric_position ||=
+        if @earth_geometric
+          barycentric_position - @earth_geometric.position
+        else
+          barycentric_position
+        end
+    end
+
+    def barycentric_position
+      if use_stellar_propagation?
         stellar_propagation.position
       else
         astronomical_distance = DEFAULT_DISTANCE.meters

--- a/spec/astronoby/bodies/deep_sky_object_position_spec.rb
+++ b/spec/astronoby/bodies/deep_sky_object_position_spec.rb
@@ -193,28 +193,28 @@ RSpec.describe Astronoby::DeepSkyObjectPosition do
       apparent = dso.apparent
 
       expect(apparent.equatorial.right_ascension.str(:hms))
-        .to eq("18h 37m 48.708s")
+        .to eq("18h 37m 48.6969s")
       # Skyfield:   18h 37m 48.70s
       # Astropy:    18h 37m 48.6459s
       # Stellarium: 18h 37m 48.47s
       # SkySafari:  18h 37m 48.28s
 
       expect(apparent.equatorial.declination.str(:dms))
-        .to eq("+38° 48′ 41.4968″")
+        .to eq("+38° 48′ 41.4946″")
       # Skyfield:   +38° 48′ 41.5″
       # Astropy:    +38° 48′ 50.5021″
       # Stellarium: +38° 48′ 42.9″
       # SkySafari:  +38° 48′ 16.1″
 
       expect(apparent.ecliptic.latitude.str(:dms))
-        .to eq("+61° 44′ 11.4469″")
+        .to eq("+61° 44′ 11.4625″")
       # Skyfield:   +61° 44′ 11.5″
       # Astropy:    +61° 44′ 11.4624″
       # Stellarium: +61° 44′ 13.2″
       # SkySafari:  +61° 43′ 47.0″
 
       expect(apparent.ecliptic.longitude.str(:dms))
-        .to eq("+285° 40′ 47.2902″")
+        .to eq("+285° 40′ 47.0186″")
       # Skyfield:   +285° 40′ 47.0″
       # Astropy:    +285° 40′ 47.0272″
       # Stellarium: +285° 40′ 41.9″
@@ -378,23 +378,23 @@ RSpec.describe Astronoby::DeepSkyObjectPosition do
       topocentric = dso.observed_by(observer)
 
       expect(topocentric.equatorial.right_ascension.str(:hms))
-        .to eq("18h 37m 48.708s")
+        .to eq("18h 37m 48.6969s")
       # Skyfield: 18h 37m 48.70s
       # Astropy:  18h 37m 29.3159s
 
       expect(topocentric.equatorial.declination.str(:dms))
-        .to eq("+38° 48′ 41.4968″")
+        .to eq("+38° 48′ 41.4946″")
       # Skyfield: +38° 48′ 41.6″
       # Astropy:  +38° 48′ 41.6272″
 
       expect(topocentric.horizontal.altitude.str(:dms))
-        .to eq("+26° 30′ 4.2981″")
+        .to eq("+26° 30′ 4.2015″")
       # Skyfield:   +26° 30′ 4.2″
       # Astropy:    +26° 30′ 4.1613″
       # Stellarium: +26° 30′ 4.1″
 
       expect(topocentric.horizontal.azimuth.str(:dms))
-        .to eq("+299° 35′ 16.2801″")
+        .to eq("+299° 35′ 16.3765″")
       # Skyfield:   +299° 35′ 16.6″
       # Astropy:    +299° 35′ 16.1035″
       # Stellarium: +299° 35′ 18.7″

--- a/spec/astronoby/events/rise_transit_set_calculator_spec.rb
+++ b/spec/astronoby/events/rise_transit_set_calculator_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe Astronoby::RiseTransitSetCalculator do
 
         aggregate_failures do
           expect(events.rising_times.first)
-            .to eq Time.utc(2025, 10, 1, 1, 31, 27)
+            .to eq Time.utc(2025, 10, 1, 1, 31, 28)
           # USNO:       2025-10-01T01:31    UTC
           # Stellarium: 2025-10-01T01:31:27 UTC
           # Skyfield:   2025-10-01T01:36    UTC


### PR DESCRIPTION
The geocentric position of a deep-sky object did not include annual parallax. `DeepSkyObjectPosition` propagated the star's barycentric position correctly (proper motion and space velocity) but then used that barycentric vector as if it were geocentric, never subtracting the observer's position. The annual parallax (the Earth-position offset, up to the parallax angle) was therefore missing from the astrometric, apparent and topocentric positions, and from rise/transit/set times.