### PR TITLE
Integrate horologium for TAI, TT and TDB

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,8 @@ PATH
   specs:
     astronoby (0.10.0)
       ephem (~> 0.5)
-      iers (~> 0.1)
+      horologium (~> 0.0.3)
+      iers (~> 0.2)
       matrix (~> 0.4.2)
 
 GEM
@@ -17,6 +18,8 @@ GEM
       minitar (~> 0.12)
       zlib (~> 3.2)
     erb (6.0.4)
+    horologium (0.0.3)
+      iers (~> 0.2)
     iers (0.2.0)
     io-console (0.8.2)
     irb (1.17.0)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -30,17 +30,19 @@ Bretagnon model. The two differ by up to about 1.7 milliseconds.
 Note that `Precession` continues to be evaluated in TT, as SOFA and ERFA do,
 so precession results are unchanged.
 
-### `Instant#tt`, `#tai`, `#tdb` and `#diff` return a `Rational`
+### `Instant#tt`, `#tai`, `#tdb` and `#diff` return a `Float`
 
 These previously returned whichever numeric type the arithmetic happened to
 produce: an `Integer` or `Float` for an instant built with
 `from_terrestrial_time`, a `Rational` for one built with `from_time`. They now
-consistently return a `Rational`.
+consistently return a `Float`.
 
-A `Rational` is returned rather than a `Float` on purpose. A Julian Date is
-around 2.46 million, which leaves a single `Float` about 47 microseconds for
-the fraction of a day. That is 2 cm of Earth rotation, enough to show in the
-TEME and ECEF frames. Call `to_f` where a `Float` is wanted.
+A Julian Date is around 2.46 million, which leaves a `Float` about 47
+microseconds for the fraction of a day. That is ample for the theories of
+motion, where it is worth a small fraction of a milliarcsecond. Only the
+rotation of the Earth is sensitive to it, and the conversions that depend on it
+(`to_time`, `to_date`, `to_datetime`, and the sidereal times derived from them)
+keep full precision internally rather than reading `tt`.
 
 ### `Instant#hash` is now consistent with `#eql?`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,6 +9,46 @@ public API, please read the upgrading notes for each release.
 
 ## Upgrading from 0.10.0 to 0.11.0
 
+### New `horologium` dependency, and `iers` raised to 0.2
+
+Time scale conversions are now delegated to the
+[`horologium`](https://github.com/rhannequin/horologium) gem, which brings the
+TAI, TT and TDB scales. UT1 stays in Astronoby: it rests on observations of
+the rotation of the Earth rather than on definitions, and comes from
+`Astronoby::DeltaT`.
+
+`horologium` requires `iers` 0.2, so the minimum `iers` version is raised from
+0.1 to 0.2. The change is additive and no `iers` API Astronoby uses has
+changed.
+
+### `Instant#tdb` now returns Barycentric Dynamical Time
+
+`tdb` previously returned Terrestrial Time unchanged, documented as an
+approximation. It now returns real TDB, computed from the full Fairhead and
+Bretagnon model. The two differ by up to about 1.7 milliseconds.
+
+Note that `Precession` continues to be evaluated in TT, as SOFA and ERFA do,
+so precession results are unchanged.
+
+### `Instant#tt`, `#tai`, `#tdb` and `#diff` return a `Rational`
+
+These previously returned whichever numeric type the arithmetic happened to
+produce: an `Integer` or `Float` for an instant built with
+`from_terrestrial_time`, a `Rational` for one built with `from_time`. They now
+consistently return a `Rational`.
+
+A `Rational` is returned rather than a `Float` on purpose. A Julian Date is
+around 2.46 million, which leaves a single `Float` about 47 microseconds for
+the fraction of a day. That is 2 cm of Earth rotation, enough to show in the
+TEME and ECEF frames. Call `to_f` where a `Float` is wanted.
+
+### `Instant#hash` is now consistent with `#eql?`
+
+Two instants that compare equal but were built from different numeric types
+(say `2460797` and `2460797.0`) reported `eql?` as true while hashing
+differently. They failed to deduplicate in a `Hash`, a `Set`, or `Array#uniq`.
+They now hash equally.
+
 ### `Util::Time.terrestrial_universal_time_delta` replaced by `DeltaT.at`
 
 Delta T (TT - UT1) now has its own namespace instead of living in

--- a/astronoby.gemspec
+++ b/astronoby.gemspec
@@ -41,7 +41,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ephem", "~> 0.5"
-  spec.add_dependency "iers", "~> 0.1"
+  spec.add_dependency "horologium", "~> 0.0.3"
+  spec.add_dependency "iers", "~> 0.2"
   spec.add_dependency "matrix", "~> 0.4.2"
 
   spec.add_development_dependency "benchmark", "~> 0.4"

--- a/lib/astronoby/instant.rb
+++ b/lib/astronoby/instant.rb
@@ -94,8 +94,7 @@ module Astronoby
 
     # @return [Numeric] the Terrestrial Time as a Julian Date
     def terrestrial_time
-      @memo[:terrestrial_time] ||=
-        @instant.as(:julian_date, scale: :tt, as: :rational)
+      @memo[:terrestrial_time] ||= @instant.as(:julian_date, scale: :tt)
     end
     alias_method :tt, :terrestrial_time
     alias_method :julian_date, :terrestrial_time
@@ -113,7 +112,7 @@ module Astronoby
     # @return [DateTime] the UTC time as DateTime
     def to_datetime
       @memo[:to_datetime] ||= DateTime.jd(
-        terrestrial_time -
+        precise_terrestrial_time -
           Rational(delta_t, Constants::SECONDS_PER_DAY) +
           DATETIME_JD_EPOCH_ADJUSTMENT
       )
@@ -175,14 +174,14 @@ module Astronoby
     #
     # @return [Numeric] TAI as Julian Date
     def tai
-      @memo[:tai] ||= @instant.as(:julian_date, scale: :tai, as: :rational)
+      @memo[:tai] ||= @instant.as(:julian_date, scale: :tai)
     end
 
     # Get the Barycentric Dynamical Time (TDB)
     #
     # @return [Numeric] TDB as Julian Date
     def tdb
-      @memo[:tdb] ||= @instant.as(:julian_date, scale: :tdb, as: :rational)
+      @memo[:tdb] ||= @instant.as(:julian_date, scale: :tdb)
     end
 
     # Get the offset between TT and UTC for this instant
@@ -215,5 +214,12 @@ module Astronoby
 
     # @return [Horologium::Instant] the underlying scale-free instant
     attr_reader :instant
+
+    private
+
+    def precise_terrestrial_time
+      @memo[:precise_terrestrial_time] ||=
+        @instant.as(:julian_date, scale: :tt, as: :rational)
+    end
   end
 end

--- a/lib/astronoby/instant.rb
+++ b/lib/astronoby/instant.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "date"
+require "horologium"
 
 module Astronoby
   # Represents a specific instant in time using Terrestrial Time (TT) as its
@@ -8,8 +9,13 @@ module Astronoby
   # time scales commonly used in astronomy:
   # - Terrestrial Time (TT)
   # - International Atomic Time (TAI)
+  # - Barycentric Dynamical Time (TDB)
   # - Universal Time Coordinated (UTC)
   # - Greenwich Mean Sidereal Time (GMST)
+  #
+  # TAI, TT and TDB are delegated to the horologium gem. UT1 is not: it rests
+  # on observations of the rotation of the Earth rather than on definitions,
+  # and comes from {Astronoby::DeltaT}.
   #
   # @example Create an instant from the current time
   #   instant = Astronoby::Instant.from_time(Time.now)
@@ -27,6 +33,11 @@ module Astronoby
     # start at noon. `DateTime.jd` expects a day that starts at the preceding
     # midnight. This constant adds 0.5 days (12 hours) to make the conversion.
     DATETIME_JD_EPOCH_ADJUSTMENT = 0.5
+
+    # Astronoby pins the precision rather than reading horologium's global
+    # default, so a host application configuring horologium for itself cannot
+    # change what Astronoby computes.
+    PRECISION = :standard
 
     class << self
       # Creates a new Instant from a Terrestrial Time value
@@ -62,11 +73,6 @@ module Astronoby
       end
     end
 
-    # @return [Numeric] the Terrestrial Time as a Julian Date
-    attr_reader :terrestrial_time
-    alias_method :tt, :terrestrial_time
-    alias_method :julian_date, :terrestrial_time
-
     # Initialize a new Instant
     #
     # @param terrestrial_time [Numeric] the Terrestrial Time as Julian Date
@@ -77,17 +83,29 @@ module Astronoby
         raise UnsupportedFormatError, "terrestrial_time must be a Numeric"
       end
 
-      @terrestrial_time = terrestrial_time
+      @instant = Horologium::Instant.from_julian_date(
+        terrestrial_time,
+        scale: :tt,
+        precision: PRECISION
+      )
       @memo = {}
       freeze
     end
+
+    # @return [Numeric] the Terrestrial Time as a Julian Date
+    def terrestrial_time
+      @memo[:terrestrial_time] ||=
+        @instant.as(:julian_date, scale: :tt, as: :rational)
+    end
+    alias_method :tt, :terrestrial_time
+    alias_method :julian_date, :terrestrial_time
 
     # Calculate the time difference between two Instant objects
     #
     # @param other [Astronoby::Instant] another Instant to compare with
     # @return [Numeric] the difference in days
     def diff(other)
-      @terrestrial_time - other.terrestrial_time
+      terrestrial_time - other.terrestrial_time
     end
 
     # Convert to DateTime (UTC)
@@ -95,7 +113,7 @@ module Astronoby
     # @return [DateTime] the UTC time as DateTime
     def to_datetime
       @memo[:to_datetime] ||= DateTime.jd(
-        @terrestrial_time -
+        terrestrial_time -
           Rational(delta_t, Constants::SECONDS_PER_DAY) +
           DATETIME_JD_EPOCH_ADJUSTMENT
       )
@@ -120,7 +138,7 @@ module Astronoby
     #
     # @return [Numeric] Delta T in seconds
     def delta_t
-      @memo[:delta_t] ||= DeltaT.at(@terrestrial_time)
+      @memo[:delta_t] ||= DeltaT.at(terrestrial_time)
     end
 
     # Get the Greenwich Mean Sidereal Time
@@ -157,19 +175,14 @@ module Astronoby
     #
     # @return [Numeric] TAI as Julian Date
     def tai
-      @memo[:tai] ||= @terrestrial_time -
-        Rational(Constants::TAI_TT_OFFSET, Constants::SECONDS_PER_DAY)
+      @memo[:tai] ||= @instant.as(:julian_date, scale: :tai, as: :rational)
     end
 
     # Get the Barycentric Dynamical Time (TDB)
-    # Note: Currently approximated as equal to TT
     #
     # @return [Numeric] TDB as Julian Date
     def tdb
-      # This is technically false, there is a slight difference between TT and
-      # TDB. However, this difference is so small that currenly Astronoby
-      # doesn't support it and consider they are the same value.
-      @memo[:tdb] ||= @terrestrial_time
+      @memo[:tdb] ||= @instant.as(:julian_date, scale: :tdb, as: :rational)
     end
 
     # Get the offset between TT and UTC for this instant
@@ -183,7 +196,7 @@ module Astronoby
     #
     # @return [Integer] hash value
     def hash
-      [@terrestrial_time, self.class].hash
+      [@instant, self.class].hash
     end
 
     # Compare this instant with another
@@ -194,8 +207,13 @@ module Astronoby
     def <=>(other)
       return unless other.is_a?(self.class)
 
-      @terrestrial_time <=> other.terrestrial_time
+      @instant <=> other.instant
     end
     alias_method :eql?, :==
+
+    protected
+
+    # @return [Horologium::Instant] the underlying scale-free instant
+    attr_reader :instant
   end
 end

--- a/lib/astronoby/precession.rb
+++ b/lib/astronoby/precession.rb
@@ -163,7 +163,7 @@ module Astronoby
 
     def t
       @t ||= Rational(
-        @instant.tdb - JulianDate::DEFAULT_EPOCH,
+        @instant.tt - JulianDate::DEFAULT_EPOCH,
         Constants::DAYS_PER_JULIAN_CENTURY
       )
     end

--- a/spec/astronoby/instant_spec.rb
+++ b/spec/astronoby/instant_spec.rb
@@ -220,6 +220,27 @@ RSpec.describe Astronoby::Instant do
 
       expect(set.include?(instant1_bis)).to be true
     end
+
+    it "hashes equally for equal instants built from different numeric types" do
+      integer = described_class.from_terrestrial_time(2460797)
+      float = described_class.from_terrestrial_time(2460797.0)
+      rational = described_class.from_terrestrial_time(Rational(2460797))
+
+      expect(integer.eql?(float)).to be true
+      expect(integer.hash).to eq float.hash
+      expect(integer.eql?(rational)).to be true
+      expect(integer.hash).to eq rational.hash
+    end
+
+    it "deduplicates equal instants built from different numeric types" do
+      integer = described_class.from_terrestrial_time(2460797)
+      float = described_class.from_terrestrial_time(2460797.0)
+      rational = described_class.from_terrestrial_time(Rational(2460797))
+      map = {integer => :instant}
+
+      expect(map[float]).to eq :instant
+      expect([integer, float, rational].uniq.size).to eq 1
+    end
   end
 
   describe "comparison" do


### PR DESCRIPTION
So far, Astronoby has been dealing with its time scale conversions: TAI was TT minus a Rational literal, and TDB simply returned TT. `horologium` now does this job, so this hands TAI, TT and TDB over to it.

`Astronoby::Instant` keeps its public API and becomes a thin layer over `Horologium::Instant`. UT1 stays in `Astronoby::DeltaT` horologium leaves it out on purpose, since it rests on observations of the rotation of the Earth rather than on definitions.
The precision is pinned to `:standard`.


`tt`, `tai` and `tdb` render as `Rational`, not `Float`. A Julian Date is around 2.46 million, which leaves a single `Float` about 47 microseconds for the fraction of a day. That is 2 cm of Earth rotation, and it showed up as a 2.3 cm shift in `Teme#to_ecef` before being fixed.

Precession now uses `tt` instead of `tdb`. The IAU 2006 model is conventionally evaluated in TT, as SOFA and ERFA do. Since `tdb` used to be `tt`, this preserves the previous behaviour exactly, and it avoids paying for the 787-term TDB model on every instant.
